### PR TITLE
fix: Algolia - query with filters to get accurate pill counts

### DIFF
--- a/src/components/catalogs/EnterpriseCatalogs.jsx
+++ b/src/components/catalogs/EnterpriseCatalogs.jsx
@@ -8,11 +8,11 @@ import { FormattedMessage } from '@edx/frontend-platform/i18n';
 import PageWrapper from '../PageWrapper';
 import { NUM_RESULTS_PER_PAGE } from '../../constants';
 import CatalogSearchResults from './CatalogSearchResults';
-import { useAlgoliaIndex } from './data/hooks';
+import { useAlgoliaIndex, useDefaultSearchFilters } from './data/hooks';
 
 export default function EnterpriseCatalogs() {
   const { algoliaIndexName, searchClient } = useAlgoliaIndex();
-
+  const filters = useDefaultSearchFilters();
   return (
     <>
       <PageWrapper className="enterprise-catalogs">
@@ -27,7 +27,7 @@ export default function EnterpriseCatalogs() {
             indexName={algoliaIndexName}
             searchClient={searchClient}
           >
-            <Configure hitsPerPage={NUM_RESULTS_PER_PAGE} />
+            <Configure hitsPerPage={NUM_RESULTS_PER_PAGE} filters={filters} />
             <div className="enterprise-catalogs-header"><SearchHeader variant="default" /></div>
             <CatalogSearchResults />
           </InstantSearch>

--- a/src/components/catalogs/data/hooks.jsx
+++ b/src/components/catalogs/data/hooks.jsx
@@ -1,9 +1,11 @@
 /* eslint-disable import/prefer-default-export */
-import { useMemo } from 'react';
+import { useContext, useMemo } from 'react';
 
 import algoliasearch from 'algoliasearch/lite';
 
 import { getConfig } from '@edx/frontend-platform';
+import { SearchContext } from '@edx/frontend-enterprise';
+import { QUERY_UUID_REFINEMENT } from '../../../constants';
 
 const useAlgoliaIndex = () => {
   // note: calling the getConfig outside of a hook/render function won't work
@@ -21,7 +23,34 @@ const useMarketingSite = () => {
   return config.HUBSPOT_MARKETING_URL;
 };
 
+const useDefaultSearchFilters = () => {
+  const { refinementsFromQueryParams } = useContext(SearchContext);
+  const config = getConfig();
+  const allQueryUuids = [
+    config.EDX_FOR_BUSINESS_UUID,
+    config.EDX_FOR_ONLINE_EDU_UUID,
+    config.EDX_ONLINE_ESSENTIALS_UUID,
+  ];
+  const filters = (uuids) => {
+    const queryReducer = (result, uuid, index) => {
+      const isLastCatalogQuery = index === uuids.length - 1;
+      let query = ''.concat(result, 'enterprise_catalog_query_uuids:').concat(uuid);
+      if (!isLastCatalogQuery) {
+        query += ' OR ';
+      }
+      return query;
+    };
+
+    return uuids.reduce(queryReducer, '');
+  };
+  if (!refinementsFromQueryParams[QUERY_UUID_REFINEMENT]) {
+    return filters(allQueryUuids);
+  }
+  return filters(refinementsFromQueryParams[QUERY_UUID_REFINEMENT]);
+};
+
 export {
   useAlgoliaIndex,
   useMarketingSite,
+  useDefaultSearchFilters,
 };

--- a/src/components/catalogs/tests/data/hooks.test.jsx
+++ b/src/components/catalogs/tests/data/hooks.test.jsx
@@ -1,11 +1,18 @@
+import React from 'react';
+
 import { renderHook } from '@testing-library/react-hooks';
 
-import { useAlgoliaIndex, useMarketingSite } from '../../data/hooks';
+import { SearchContext } from '@edx/frontend-enterprise';
+import { useAlgoliaIndex, useDefaultSearchFilters, useMarketingSite } from '../../data/hooks';
+import { QUERY_UUID_REFINEMENT } from '../../../../constants';
 
 const indexName = 'test';
 const appid = 'test app';
 const key = 'test key';
 const marketingSite = 'http://test.edx.org';
+const businessUuid = 'ayylmao';
+const eduUuid = 'foo';
+const essentialsUuid = 'bar';
 
 const mockConfig = () => (
   {
@@ -13,6 +20,9 @@ const mockConfig = () => (
     ALGOLIA_APP_ID: appid,
     ALGOLIA_SEARCH_API_KEY: key,
     HUBSPOT_MARKETING_URL: marketingSite,
+    EDX_FOR_BUSINESS_UUID: businessUuid,
+    EDX_FOR_ONLINE_EDU_UUID: eduUuid,
+    EDX_ONLINE_ESSENTIALS_UUID: essentialsUuid,
   }
 );
 
@@ -31,5 +41,28 @@ describe('hooks function tests', () => {
   test('marketing site url resolves from config', () => {
     const { result } = renderHook(() => useMarketingSite());
     expect(result.current).toBe(marketingSite);
+  });
+
+  test('all catalog queries are rendered as query params when no query refinements exist', () => {
+    // eslint-disable-next-line react/prop-types
+    const wrapper = ({ children }) => (
+      <SearchContext.Provider value={{ refinementsFromQueryParams: {} }}>
+        {children}
+      </SearchContext.Provider>
+    );
+    const { result } = renderHook(() => useDefaultSearchFilters(), { wrapper });
+    [essentialsUuid, businessUuid, eduUuid].forEach(uuid => expect(result.current).toContain(uuid));
+  });
+  test('only queries specified in query refinements are rendered as query params', () => {
+    const queryUuid = 'blargl';
+    // eslint-disable-next-line react/prop-types
+    const wrapper = ({ children }) => (
+      <SearchContext.Provider value={{ refinementsFromQueryParams: { [QUERY_UUID_REFINEMENT]: [queryUuid] } }}>
+        {children}
+      </SearchContext.Provider>
+    );
+    const { result } = renderHook(() => useDefaultSearchFilters(), { wrapper });
+    [essentialsUuid, businessUuid, eduUuid].forEach(uuid => expect(result.current).not.toContain(uuid));
+    expect(result.current).toContain(queryUuid);
   });
 });


### PR DESCRIPTION
When we do not filter our initial query to Algolia, facet counts are based on the total records in the index while the result set is inherently deduped.
This means that if we get 500 hits from our search we may have pill facet values of 47000.

If you filter on your initial query, the facet counts seem to be based on the filtered result set (which is also already deduped). 
Note: I am still waiting on Algolia support to explain why this is exactly, but regardless....

Thus, I have added functionality to filter by all of our catalog queries prior to a user selecting one.
If they do select a catalog query, it swaps to that as normal.

From the UI perspective there should be absolutely no change and mostly functionally there is no change, except that we actually get useful counts.

#### Algolia FormData before this change:
![Screen Shot 2021-06-04 at 3 25 17 PM](https://user-images.githubusercontent.com/66267747/120854152-bfbcb800-c54a-11eb-94e8-090567180c8c.png)

#### Algolia data and view after this change:
![Screen Shot 2021-06-04 at 3 24 18 PM](https://user-images.githubusercontent.com/66267747/120854166-c8ad8980-c54a-11eb-9637-c974f4eabb42.png)


(If you couldn't tell, before, we had no filters, after we filter on using all 3 catalogs)