### PR TITLE
Fix: Force calculation of facets (the pill counts) to occur after results (aka deduplication) returned.

### DIFF
--- a/src/components/catalogs/EnterpriseCatalogs.jsx
+++ b/src/components/catalogs/EnterpriseCatalogs.jsx
@@ -27,7 +27,7 @@ export default function EnterpriseCatalogs() {
             indexName={algoliaIndexName}
             searchClient={searchClient}
           >
-            <Configure hitsPerPage={NUM_RESULTS_PER_PAGE} filters={filters} />
+            <Configure hitsPerPage={NUM_RESULTS_PER_PAGE} filters={filters} facetingAfterDistinct />
             <div className="enterprise-catalogs-header"><SearchHeader variant="default" /></div>
             <CatalogSearchResults />
           </InstantSearch>


### PR DESCRIPTION
Algolia support has indicated that facets are always calculated before deduplication unless using `facetingAfterDistinct`. The reason us just filtering seemed to work was because the values we were filtering on happened to not have any duplicated results. (Thus we should really apply this setting to the learner portal as well to ensure no weird counts there).

This PR just adds that `facetingAfterDistinct` flag to the configuration for our queries.

### Behavior on Prod:
![Screen Shot 2021-06-14 at 12 28 15 PM](https://user-images.githubusercontent.com/66267747/121926964-86cfd080-cd0c-11eb-8b4b-37d387200069.png)

### Behaviour locally with this change:
![Screen Shot 2021-06-14 at 12 26 04 PM](https://user-images.githubusercontent.com/66267747/121927089-a8c95300-cd0c-11eb-9461-44102ca10700.png)

(Ignore any weird UX differences, it's due to the brand themes being different)
