### PR TITLE
fix: revert changes from ent-4539 - Show all courses

### DIFF
--- a/src/components/catalogs/EnterpriseCatalogs.jsx
+++ b/src/components/catalogs/EnterpriseCatalogs.jsx
@@ -8,11 +8,11 @@ import { FormattedMessage } from '@edx/frontend-platform/i18n';
 import PageWrapper from '../PageWrapper';
 import { NUM_RESULTS_PER_PAGE } from '../../constants';
 import CatalogSearchResults from './CatalogSearchResults';
-import { useAlgoliaIndex, useDefaultSearchFilters } from './data/hooks';
+import { useAlgoliaIndex } from './data/hooks';
 
 export default function EnterpriseCatalogs() {
   const { algoliaIndexName, searchClient } = useAlgoliaIndex();
-  const filters = useDefaultSearchFilters();
+
   return (
     <>
       <PageWrapper className="enterprise-catalogs">
@@ -27,7 +27,7 @@ export default function EnterpriseCatalogs() {
             indexName={algoliaIndexName}
             searchClient={searchClient}
           >
-            <Configure hitsPerPage={NUM_RESULTS_PER_PAGE} filters={filters} facetingAfterDistinct />
+            <Configure hitsPerPage={NUM_RESULTS_PER_PAGE} facetingAfterDistinct />
             <div className="enterprise-catalogs-header"><SearchHeader variant="default" /></div>
             <CatalogSearchResults />
           </InstantSearch>

--- a/src/components/catalogs/data/hooks.jsx
+++ b/src/components/catalogs/data/hooks.jsx
@@ -1,11 +1,9 @@
 /* eslint-disable import/prefer-default-export */
-import { useContext, useMemo } from 'react';
+import { useMemo } from 'react';
 
 import algoliasearch from 'algoliasearch/lite';
 
 import { getConfig } from '@edx/frontend-platform';
-import { SearchContext } from '@edx/frontend-enterprise-catalog-search';
-import { QUERY_UUID_REFINEMENT } from '../../../constants';
 
 const useAlgoliaIndex = () => {
   // note: calling the getConfig outside of a hook/render function won't work
@@ -23,34 +21,7 @@ const useMarketingSite = () => {
   return config.HUBSPOT_MARKETING_URL;
 };
 
-const useDefaultSearchFilters = () => {
-  const { refinementsFromQueryParams } = useContext(SearchContext);
-  const config = getConfig();
-  const allQueryUuids = [
-    config.EDX_FOR_BUSINESS_UUID,
-    config.EDX_FOR_ONLINE_EDU_UUID,
-    config.EDX_ONLINE_ESSENTIALS_UUID,
-  ];
-  const filters = (uuids) => {
-    const queryReducer = (result, uuid, index) => {
-      const isLastCatalogQuery = index === uuids.length - 1;
-      let query = ''.concat(result, 'enterprise_catalog_query_uuids:').concat(uuid);
-      if (!isLastCatalogQuery) {
-        query += ' OR ';
-      }
-      return query;
-    };
-
-    return uuids.reduce(queryReducer, '');
-  };
-  if (!refinementsFromQueryParams[QUERY_UUID_REFINEMENT]) {
-    return filters(allQueryUuids);
-  }
-  return filters(refinementsFromQueryParams[QUERY_UUID_REFINEMENT]);
-};
-
 export {
   useAlgoliaIndex,
   useMarketingSite,
-  useDefaultSearchFilters,
 };

--- a/src/components/catalogs/tests/data/hooks.test.jsx
+++ b/src/components/catalogs/tests/data/hooks.test.jsx
@@ -1,18 +1,11 @@
-import React from 'react';
-
 import { renderHook } from '@testing-library/react-hooks';
 
-import { SearchContext } from '@edx/frontend-enterprise-catalog-search';
-import { useAlgoliaIndex, useDefaultSearchFilters, useMarketingSite } from '../../data/hooks';
-import { QUERY_UUID_REFINEMENT } from '../../../../constants';
+import { useAlgoliaIndex, useMarketingSite } from '../../data/hooks';
 
 const indexName = 'test';
 const appid = 'test app';
 const key = 'test key';
 const marketingSite = 'http://test.edx.org';
-const businessUuid = 'ayylmao';
-const eduUuid = 'foo';
-const essentialsUuid = 'bar';
 
 const mockConfig = () => (
   {
@@ -20,9 +13,6 @@ const mockConfig = () => (
     ALGOLIA_APP_ID: appid,
     ALGOLIA_SEARCH_API_KEY: key,
     HUBSPOT_MARKETING_URL: marketingSite,
-    EDX_FOR_BUSINESS_UUID: businessUuid,
-    EDX_FOR_ONLINE_EDU_UUID: eduUuid,
-    EDX_ONLINE_ESSENTIALS_UUID: essentialsUuid,
   }
 );
 
@@ -41,28 +31,5 @@ describe('hooks function tests', () => {
   test('marketing site url resolves from config', () => {
     const { result } = renderHook(() => useMarketingSite());
     expect(result.current).toBe(marketingSite);
-  });
-
-  test('all catalog queries are rendered as query params when no query refinements exist', () => {
-    // eslint-disable-next-line react/prop-types
-    const wrapper = ({ children }) => (
-      <SearchContext.Provider value={{ refinementsFromQueryParams: {} }}>
-        {children}
-      </SearchContext.Provider>
-    );
-    const { result } = renderHook(() => useDefaultSearchFilters(), { wrapper });
-    [essentialsUuid, businessUuid, eduUuid].forEach(uuid => expect(result.current).toContain(uuid));
-  });
-  test('only queries specified in query refinements are rendered as query params', () => {
-    const queryUuid = 'blargl';
-    // eslint-disable-next-line react/prop-types
-    const wrapper = ({ children }) => (
-      <SearchContext.Provider value={{ refinementsFromQueryParams: { [QUERY_UUID_REFINEMENT]: [queryUuid] } }}>
-        {children}
-      </SearchContext.Provider>
-    );
-    const { result } = renderHook(() => useDefaultSearchFilters(), { wrapper });
-    [essentialsUuid, businessUuid, eduUuid].forEach(uuid => expect(result.current).not.toContain(uuid));
-    expect(result.current).toContain(queryUuid);
   });
 });


### PR DESCRIPTION
The initial attempt to fix the facet counts in ent-4539 made the conscious change to pre-filter our result set. We filtered to the 3 catalog options listed in the explore-catalog and selecting any 1 just isolated the results down to that specific catalog.

The behaviour product actually wants is to show *all* courses (not just the ones in those 3 catalogs) prior to filtering.
With the implementation of ENT-4664, we can do this and *still* fix the underlying issue with facet counts (since 4664 contains the actual fix)

If you look here: https://github.com/edx/frontend-app-enterprise-public-catalog/pull/49
You can see I'm just reverting what I added. We had to do some string concatenation to be able to query multiple catalogs at once.

### Before this Change (Production index values):
![Screen Shot 2021-06-16 at 3 06 12 PM](https://user-images.githubusercontent.com/66267747/122277929-6d698880-ceb4-11eb-91b7-a772a691a624.png)

### After this Change:
![Screen Shot 2021-06-16 at 2 55 28 PM](https://user-images.githubusercontent.com/66267747/122277949-72c6d300-ceb4-11eb-9c1b-75e60a817509.png)
