### PR TITLE
build: :arrow_up: Upgrade to frontend-enterprise 2.0.7 and fix breaking changes as a result.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3307,6 +3307,11 @@
       "resolved": "https://registry.npmjs.org/@edx/brand-openedx/-/brand-openedx-1.1.0.tgz",
       "integrity": "sha512-ne2ZKF1r0akkt0rEzCAQAk4cTDTI2GiWCpc+T7ldQpw9X57OnUB16dKsFNe40C9uEjL5h3Ps/ZsFM5dm4cIkEQ=="
     },
+    "@edx/brand-openedx": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@edx/brand-openedx/-/brand-openedx-1.1.0.tgz",
+      "integrity": "sha512-ne2ZKF1r0akkt0rEzCAQAk4cTDTI2GiWCpc+T7ldQpw9X57OnUB16dKsFNe40C9uEjL5h3Ps/ZsFM5dm4cIkEQ=="
+    },
     "@edx/eslint-config": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/@edx/eslint-config/-/eslint-config-1.1.6.tgz",
@@ -3525,11 +3530,11 @@
       }
     },
     "@edx/frontend-enterprise-catalog-search": {
-      "version": "0.1.11",
-      "resolved": "https://registry.npmjs.org/@edx/frontend-enterprise-catalog-search/-/frontend-enterprise-catalog-search-0.1.11.tgz",
-      "integrity": "sha512-MvLR0276Qvk0kYOx9jLR0Ah8WNvo3D+GO8kQbMqdvO2zBu+GyIHs/aZmMDoUM3JcqAJkYk+CHt24arJ1v86q5g==",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-enterprise-catalog-search/-/frontend-enterprise-catalog-search-2.0.7.tgz",
+      "integrity": "sha512-Ofns4KUvpZozNRo5ugJ5L1XWMuz7NWQlaFGR42IBjG72eWo7C4T4oY4ggm8gGdtO4C2u9XF+KYeRClreXuyQaA==",
       "requires": {
-        "@edx/frontend-enterprise-utils": "^0.1.7",
+        "@edx/frontend-enterprise-utils": "^1.0.0",
         "classnames": "2.2.5",
         "lodash.debounce": "4.0.8",
         "prop-types": "15.6.2"
@@ -3552,9 +3557,9 @@
       }
     },
     "@edx/frontend-enterprise-utils": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/@edx/frontend-enterprise-utils/-/frontend-enterprise-utils-0.1.7.tgz",
-      "integrity": "sha512-rLS/Fmq+TQPFhy1yMli4e9DsCxGAKcpZp55HvjdiiIbuMpUrWqXuP/UFemL8w45yo9osw6vH0vKhqb14RX8y4A==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-enterprise-utils/-/frontend-enterprise-utils-1.0.0.tgz",
+      "integrity": "sha512-EBReGc/Kj7pYpyvy6akd3p2okQ/GRNZpomALgLmhv/kfuF2D9Z1wmmtQ+aJXLtghpHFsmUVsVOtAJxB42orN3g==",
       "requires": {
         "@testing-library/react": "11.2.6",
         "history": "4.10.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edx/frontend-app-enterprise-public-catalog",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "Frontend application template",
   "repository": {
     "type": "git",
@@ -36,9 +36,10 @@
   },
   "dependencies": {
     "@edx/brand": "npm:@edx/brand-openedx@1.1.0",
+    "@edx/brand-openedx": "^1.1.0",
     "@edx/frontend-component-footer": "10.1.6",
     "@edx/frontend-component-header": "2.2.4",
-    "@edx/frontend-enterprise-catalog-search": "0.1.11",
+    "@edx/frontend-enterprise-catalog-search": "^2.0.7",
     "@edx/frontend-platform": "1.12.4",
     "@edx/paragon": "14.14.1",
     "@fortawesome/fontawesome-svg-core": "1.2.35",

--- a/src/components/catalogPage/CatalogPage.jsx
+++ b/src/components/catalogPage/CatalogPage.jsx
@@ -27,7 +27,7 @@ const CatalogPage = ({ intl }) => {
     reloadPage = true;
   }
   if ((!loadedSearchParams.get(AVAILABILITY_REFINEMENT))) {
-    loadedSearchParams.set(AVAILABILITY_REFINEMENT, AVAILABILITY_REFINEMENT_DEFAULTS);
+    AVAILABILITY_REFINEMENT_DEFAULTS.map(a => loadedSearchParams.append(AVAILABILITY_REFINEMENT, a));
     reloadPage = true;
   }
   if (reloadPage) {

--- a/src/components/catalogSearchResults/CatalogSearchResults.jsx
+++ b/src/components/catalogSearchResults/CatalogSearchResults.jsx
@@ -80,7 +80,7 @@ export const BaseCatalogSearchResults = ({
     );
   }
 
-  const { refinementsFromQueryParams } = useContext(SearchContext);
+  const { refinements } = useContext(SearchContext);
   // NOTE: Cell is not explicity supported in DataTable, which leads to lint errors regarding {row}. However, we needed
   // to use the accessor functionality instead of just adding in additionalColumns like the Paragon documentation.
   const columns = useMemo(() => [
@@ -97,15 +97,15 @@ export const BaseCatalogSearchResults = ({
       accessor: 'enterprise_catalog_query_uuids',
       Cell: ({ row }) => (
         <div style={{ maxWidth: '400vw' }}>
-          { row.values.enterprise_catalog_query_uuids.includes(process.env.EDX_ENTERPRISE_ALACARTE_UUID) && <Badge className="alacarte-catalog">A la carte</Badge> }
-          { row.values.enterprise_catalog_query_uuids.includes(process.env.EDX_FOR_BUSINESS_UUID) && <Badge className="business-catalog">Business</Badge> }
-          { row.values.enterprise_catalog_query_uuids.includes(process.env.EDX_FOR_ONLINE_EDU_UUID) && <Badge className="education-catalog">Education</Badge> }
+          {row.values.enterprise_catalog_query_uuids.includes(process.env.EDX_ENTERPRISE_ALACARTE_UUID) && <Badge className="alacarte-catalog">A la carte</Badge>}
+          {row.values.enterprise_catalog_query_uuids.includes(process.env.EDX_FOR_BUSINESS_UUID) && <Badge className="business-catalog">Business</Badge>}
+          {row.values.enterprise_catalog_query_uuids.includes(process.env.EDX_FOR_ONLINE_EDU_UUID) && <Badge className="education-catalog">Education</Badge>}
         </div>
       ),
     },
   ], []);
 
-  const page = refinementsFromQueryParams.page || (searchState ? searchState.page : 0);
+  const page = refinements.page || (searchState ? searchState.page : 0);
 
   const tableData = useMemo(() => searchResults?.hits || [], [searchResults?.hits]);
   return (

--- a/src/components/catalogSearchResults/CatalogSearchResults.test.jsx
+++ b/src/components/catalogSearchResults/CatalogSearchResults.test.jsx
@@ -13,7 +13,7 @@ import messages from './CatalogSearchResults.messages';
 const PAGINATE_ME = 'PAGINATE ME :)';
 const PaginationComponent = () => <div>{PAGINATE_ME}</div>;
 
-const DEFAULT_SEARCH_CONTEXT_VALUE = { refinementsFromQueryParams: {} };
+const DEFAULT_SEARCH_CONTEXT_VALUE = { refinements: {} };
 
 // eslint-disable-next-line react/prop-types
 const SearchDataWrapper = ({ children, searchContextValue = DEFAULT_SEARCH_CONTEXT_VALUE }) => (

--- a/src/components/catalogSelectionCard/CatalogSelectionCard.jsx
+++ b/src/components/catalogSelectionCard/CatalogSelectionCard.jsx
@@ -13,8 +13,8 @@ import { QUERY_UUID_REFINEMENT } from '../../constants';
 export const CardCheckbox = ({
   label, queryUuid, labelDetail,
 }) => {
-  const { refinementsFromQueryParams, dispatch } = useContext(SearchContext);
-  const isChecked = refinementsFromQueryParams[QUERY_UUID_REFINEMENT]?.includes(queryUuid) || false;
+  const { refinements, dispatch } = useContext(SearchContext);
+  const isChecked = refinements[QUERY_UUID_REFINEMENT]?.includes(queryUuid) || false;
 
   const setChecked = () => {
     if (!isChecked) {

--- a/src/components/catalogSelectionCard/CatalogSelectionCard.test.jsx
+++ b/src/components/catalogSelectionCard/CatalogSelectionCard.test.jsx
@@ -12,7 +12,7 @@ import { CardCheckbox } from './CatalogSelectionCard';
 import { QUERY_UUID_REFINEMENT } from '../../constants';
 
 const dispatchSpy = jest.fn();
-const DEFAULT_SEARCH_CONTEXT_VALUE = { refinementsFromQueryParams: {}, dispatch: dispatchSpy };
+const DEFAULT_SEARCH_CONTEXT_VALUE = { refinements: {}, dispatch: dispatchSpy };
 
 // eslint-disable-next-line react/prop-types
 const SearchDataWrapper = ({ children, searchContextValue }) => (
@@ -46,7 +46,7 @@ describe('CardCheckbox', () => {
   });
   it('is checked when uuid is included in the query param', () => {
     const queryUuid = 'bar';
-    const refinements = { refinementsFromQueryParams: { [QUERY_UUID_REFINEMENT]: [queryUuid] } };
+    const refinements = { refinements: { [QUERY_UUID_REFINEMENT]: [queryUuid] } };
     const tree = renderer.create(
       <SearchDataWrapper
         searchContextValue={refinements}

--- a/src/components/catalogSelectionDeck/CatalogSelectionDeck.test.jsx
+++ b/src/components/catalogSelectionDeck/CatalogSelectionDeck.test.jsx
@@ -7,7 +7,7 @@ import { renderWithRouter } from '../tests/testUtils';
 import messages from './CatalogSelectionDeck.messages';
 import QUERY_UUID_REFINEMENT from '../../constants';
 
-const DEFAULT_SEARCH_CONTEXT_VALUE = { refinementsFromQueryParams: {} };
+const DEFAULT_SEARCH_CONTEXT_VALUE = { refinements: {} };
 
 const mockConfig = () => (
   {

--- a/src/constants.js
+++ b/src/constants.js
@@ -12,4 +12,4 @@ export const TRACKING_APP_NAME = 'explore-catalog';
 
 export const QUERY_UUID_REFINEMENT = 'enterprise_catalog_query_uuids';
 export const AVAILABILITY_REFINEMENT = 'availability';
-export const AVAILABILITY_REFINEMENT_DEFAULTS = 'Available Now,Upcoming';
+export const AVAILABILITY_REFINEMENT_DEFAULTS = ['Available Now', 'Upcoming'];


### PR DESCRIPTION
This PR upgrades the frontend-enterprise dependency to 2.0.7 and contains the fixes needed to mitigate the breaking changes from 2 major version bumps. This is necessary to pull in changes to fix ENT-3656

_Because_ this involved breaking changes from dependencies, I also upgraded the package version to 1.0.0, not that anything depends on it right now.