### PR TITLE
feat: adding course info modal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3640,9 +3640,9 @@
       }
     },
     "@edx/paragon": {
-      "version": "14.14.1",
-      "resolved": "https://registry.npmjs.org/@edx/paragon/-/paragon-14.14.1.tgz",
-      "integrity": "sha512-QO0OqH7zu/EVcv+E93eSW32IsXnF62y3+UmQ8aqAAAcn8PAXeUauckrxv0h4frdnzzoL+sfe/MsybacJdq7U7Q==",
+      "version": "16.10.0",
+      "resolved": "https://registry.npmjs.org/@edx/paragon/-/paragon-16.10.0.tgz",
+      "integrity": "sha512-D8QTEf1K/9KNvxguPTpCqErbSAglTCIVsqvHa5T25+345E0o6gexX/FsJVSnT8ZUy3YAXdaPA6FFxhwEXjxPMQ==",
       "requires": {
         "@fortawesome/fontawesome-svg-core": "^1.2.30",
         "@fortawesome/free-solid-svg-icons": "^5.14.0",
@@ -3653,36 +3653,29 @@
         "classnames": "^2.2.6",
         "email-prop-type": "^3.0.0",
         "font-awesome": "^4.7.0",
+        "lodash.uniqby": "^4.7.0",
         "mailto-link": "^1.0.0",
         "prop-types": "^15.7.2",
         "react-bootstrap": "^1.3.0",
         "react-focus-on": "^3.5.0",
         "react-popper": "^2.2.4",
         "react-proptype-conditional-require": "^1.0.4",
-        "react-responsive": "^6.1.1",
+        "react-responsive": "^8.2.0",
         "react-table": "^7.6.1",
         "react-transition-group": "^4.0.0",
-        "sanitize-html": "^1.20.0",
         "tabbable": "^4.0.0",
         "uncontrollable": "7.2.1"
       },
       "dependencies": {
-        "@fortawesome/free-solid-svg-icons": {
-          "version": "5.15.3",
-          "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-5.15.3.tgz",
-          "integrity": "sha512-XPeeu1IlGYqz4VWGRAT5ukNMd4VHUEEJ7ysZ7pSSgaEtNvSo+FLurybGJVmiqkQdK50OkSja2bfZXOeyMGRD8Q==",
-          "requires": {
-            "@fortawesome/fontawesome-common-types": "^0.2.35"
-          }
-        },
         "react-responsive": {
-          "version": "6.1.2",
-          "resolved": "https://registry.npmjs.org/react-responsive/-/react-responsive-6.1.2.tgz",
-          "integrity": "sha512-AXentVC/kN3KED9zhzJv2pu4vZ0i6cSHdTtbCScVV1MT6F5KXaG2qs5D7WLmhdaOvmiMX8UfmS4ZSO+WPwDt4g==",
+          "version": "8.2.0",
+          "resolved": "https://registry.npmjs.org/react-responsive/-/react-responsive-8.2.0.tgz",
+          "integrity": "sha512-iagCqVrw4QSjhxKp3I/YK6+ODkWY6G+YPElvdYKiUUbywwh9Ds0M7r26Fj2/7dWFFbOpcGnJE6uE7aMck8j5Qg==",
           "requires": {
             "hyphenate-style-name": "^1.0.0",
             "matchmediaquery": "^0.3.0",
-            "prop-types": "^15.6.1"
+            "prop-types": "^15.6.1",
+            "shallow-equal": "^1.1.0"
           }
         }
       }
@@ -4615,9 +4608,9 @@
       }
     },
     "@popperjs/core": {
-      "version": "2.9.2",
-      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.9.2.tgz",
-      "integrity": "sha512-VZMYa7+fXHdwIq1TDhSXoVmSPEGM/aa+6Aiq3nVVJ9bXr24zScr+NlKFKC3iPljA7ho/GAZr+d2jOf5GIRC30Q=="
+      "version": "2.9.3",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.9.3.tgz",
+      "integrity": "sha512-xDu17cEfh7Kid/d95kB6tZsLOmSWKCZKtprnhVepjsSaCij+lM3mItSJDuuHDMbCWTh8Ejmebwb+KONcCJ0eXQ=="
     },
     "@restart/context": {
       "version": "2.1.4",
@@ -4625,12 +4618,11 @@
       "integrity": "sha512-INJYZQJP7g+IoDUh/475NlGiTeMfwTXUEr3tmRneckHIxNolGOW9CTq83S8cxq0CgJwwcMzMJFchxvlwe7Rk8Q=="
     },
     "@restart/hooks": {
-      "version": "0.3.26",
-      "resolved": "https://registry.npmjs.org/@restart/hooks/-/hooks-0.3.26.tgz",
-      "integrity": "sha512-7Hwk2ZMYm+JLWcb7R9qIXk1OoUg1Z+saKWqZXlrvFwT3w6UArVNWgxYOzf+PJoK9zZejp8okPAKTctthhXLt5g==",
+      "version": "0.3.27",
+      "resolved": "https://registry.npmjs.org/@restart/hooks/-/hooks-0.3.27.tgz",
+      "integrity": "sha512-s984xV/EapUIfkjlf8wz9weP2O9TNKR96C68FfMEy2bE69+H4cNv3RD4Mf97lW7Htt7PjZrYTjSC8f3SB9VCXw==",
       "requires": {
-        "lodash": "^4.17.20",
-        "lodash-es": "^4.17.20"
+        "dequal": "^2.0.2"
       }
     },
     "@sindresorhus/is": {
@@ -5365,9 +5357,9 @@
       "dev": true
     },
     "@types/invariant": {
-      "version": "2.2.34",
-      "resolved": "https://registry.npmjs.org/@types/invariant/-/invariant-2.2.34.tgz",
-      "integrity": "sha512-lYUtmJ9BqUN688fGY1U1HZoWT1/Jrmgigx2loq4ZcJpICECm/Om3V314BxdzypO0u5PORKGMM6x0OXaljV1YFg=="
+      "version": "2.2.35",
+      "resolved": "https://registry.npmjs.org/@types/invariant/-/invariant-2.2.35.tgz",
+      "integrity": "sha512-DxX1V9P8zdJPYQat1gHyY0xj3efl8gnMVjiM9iCY6y27lj+PoQWkgjt8jDqmovPqULkKVpKRg8J36iQiA+EtEg=="
     },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.3",
@@ -5474,9 +5466,9 @@
       }
     },
     "@types/react-transition-group": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.1.tgz",
-      "integrity": "sha512-vIo69qKKcYoJ8wKCJjwSgCTM+z3chw3g18dkrDfVX665tMH7tmbDxEAnPdey4gTlwZz5QuHGzd+hul0OVZDqqQ==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.2.tgz",
+      "integrity": "sha512-KibDWL6nshuOJ0fu8ll7QnV/LVTo3PzQ9aCPnRUYPfX7eZohHwLIdNHj7pftanREzHNP4/nJa8oeM73uSiavMQ==",
       "requires": {
         "@types/react": "*"
       }
@@ -9086,6 +9078,11 @@
       "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
       "dev": true
     },
+    "dequal": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.2.tgz",
+      "integrity": "sha512-q9K8BlJVxK7hQYqa6XISGmBZbtQQWVXSrRrWreHC94rMt1QL/Impruc+7p2CYSYuVIUr+YCt6hjrs1kkdJRTug=="
+    },
     "des.js": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.1.tgz",
@@ -9235,6 +9232,7 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.3.2.tgz",
       "integrity": "sha512-5c54Bk5Dw4qAxNOI1pFEizPSjVsx5+bpJKmL2kPn8JhBUq2q09tTCa3mjijun2NfK78NMouDYNMBkOrPZiS+ig==",
+      "dev": true,
       "requires": {
         "domelementtype": "^2.0.1",
         "domhandler": "^4.2.0",
@@ -9245,6 +9243,7 @@
           "version": "4.2.0",
           "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.2.0.tgz",
           "integrity": "sha512-zk7sgt970kzPks2Bf+dwT/PLzghLnsivb9CcxkvR8Mzr66Olr0Ofd8neSbglHJHaHa2MadfoSdNlKYAaafmWfA==",
+          "dev": true,
           "requires": {
             "domelementtype": "^2.2.0"
           }
@@ -9260,7 +9259,8 @@
     "domelementtype": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.2.0.tgz",
-      "integrity": "sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A=="
+      "integrity": "sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A==",
+      "dev": true
     },
     "domexception": {
       "version": "2.0.1",
@@ -9279,18 +9279,11 @@
         }
       }
     },
-    "domhandler": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-3.3.0.tgz",
-      "integrity": "sha512-J1C5rIANUbuYK+FuFL98650rihynUOEzRLxW+90bKZRWB6A1X1Tf82GxR1qAWLyfNPRvjqfip3Q5tdYlmAa9lA==",
-      "requires": {
-        "domelementtype": "^2.0.1"
-      }
-    },
     "domutils": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.7.0.tgz",
       "integrity": "sha512-8eaHa17IwJUPAiB+SoTYBo5mCdeMgdcAoXJ59m6DT1vw+5iLS3gNoqYaRowaBKtGVrOF1Jz4yDTgYKLK2kvfJg==",
+      "dev": true,
       "requires": {
         "dom-serializer": "^1.0.1",
         "domelementtype": "^2.2.0",
@@ -9301,6 +9294,7 @@
           "version": "4.2.0",
           "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.2.0.tgz",
           "integrity": "sha512-zk7sgt970kzPks2Bf+dwT/PLzghLnsivb9CcxkvR8Mzr66Olr0Ofd8neSbglHJHaHa2MadfoSdNlKYAaafmWfA==",
+          "dev": true,
           "requires": {
             "domelementtype": "^2.2.0"
           }
@@ -9559,7 +9553,8 @@
     "entities": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
-      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="
+      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
+      "dev": true
     },
     "errno": {
       "version": "0.1.8",
@@ -10927,9 +10922,9 @@
       },
       "dependencies": {
         "tslib": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
-          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
         }
       }
     },
@@ -11674,17 +11669,6 @@
             "object.getownpropertydescriptors": "^2.0.3"
           }
         }
-      }
-    },
-    "htmlparser2": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-4.1.0.tgz",
-      "integrity": "sha512-4zDq1a1zhE4gQso/c5LP1OtrhYTncXNSpvJYtWJBtXAETPlMfi3IFNjGuQbYLuVY4ZR0QMqRVvo4Pdy9KLyP8Q==",
-      "requires": {
-        "domelementtype": "^2.0.1",
-        "domhandler": "^3.0.0",
-        "domutils": "^2.0.0",
-        "entities": "^2.0.0"
       }
     },
     "http-cache-semantics": {
@@ -16048,12 +16032,8 @@
     "lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-    },
-    "lodash-es": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
     },
     "lodash.camelcase": {
       "version": "4.3.0",
@@ -16120,6 +16100,11 @@
       "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
       "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
       "dev": true
+    },
+    "lodash.uniqby": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz",
+      "integrity": "sha1-2ZwHpmnp5tJOE2Lf4mbGdhavEwI="
     },
     "logalot": {
       "version": "2.1.0",
@@ -17627,11 +17612,6 @@
       "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
       "dev": true
     },
-    "parse-srcset": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/parse-srcset/-/parse-srcset-1.0.2.tgz",
-      "integrity": "sha1-8r0iH2zJcKk42IVWq8WJyqqiveE="
-    },
     "parse5": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
@@ -17955,6 +17935,7 @@
       "version": "7.0.35",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.35.tgz",
       "integrity": "sha512-3QT8bBJeX/S5zKTTjTCIjRF3If4avAT6kqxcASlTWEtAFCb9NH0OUxNDfgZSWdP5fJnBYCMEWkIFfWeugjzYMg==",
+      "dev": true,
       "requires": {
         "chalk": "^2.4.2",
         "source-map": "^0.6.1",
@@ -18944,9 +18925,9 @@
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.14.0",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.0.tgz",
-          "integrity": "sha512-JELkvo/DlpNdJ7dlyw/eY7E0suy5i5GQH+Vlxaq1nsNJ+H7f4Vtv3jMeCEgRhZZQFXTjldYfQgv2qmM6M1v5wA==",
+          "version": "7.15.3",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.15.3.tgz",
+          "integrity": "sha512-OvwMLqNXkCXSz1kSm58sEsNuhqOx/fKpnUnKnFB5v8uDda5bLNEHNgKPvhDN6IU0LDcnHQ90LlJ0Q6jnyBSIBA==",
           "requires": {
             "regenerator-runtime": "^0.13.4"
           }
@@ -19162,16 +19143,16 @@
       "integrity": "sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA=="
     },
     "react-focus-lock": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.5.1.tgz",
-      "integrity": "sha512-gOToRZKVEymGEjFaTRUKgJsdYQrNosoiK7yZnXnnd8bYew4vMzk3Rxb0Q4nyrGwsFuUmgQiSAulQirA0J+v4hA==",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.5.2.tgz",
+      "integrity": "sha512-WzpdOnEqjf+/A3EH9opMZWauag7gV0BxFl+EY4ElA4qFqYsUsBLnmo2sELbN5OC30S16GAWMy16B9DLPpdJKAQ==",
       "requires": {
         "@babel/runtime": "^7.0.0",
         "focus-lock": "^0.9.1",
         "prop-types": "^15.6.2",
-        "react-clientside-effect": "^1.2.2",
-        "use-callback-ref": "^1.2.1",
-        "use-sidecar": "^1.0.1"
+        "react-clientside-effect": "^1.2.5",
+        "use-callback-ref": "^1.2.5",
+        "use-sidecar": "^1.0.5"
       }
     },
     "react-focus-on": {
@@ -19253,9 +19234,9 @@
       }
     },
     "react-overlays": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/react-overlays/-/react-overlays-5.0.1.tgz",
-      "integrity": "sha512-plwUJieTBbLSrgvQ4OkkbTD/deXgxiJdNuKzo6n1RWE3OVnQIU5hffCGS/nvIuu6LpXFs2majbzaXY8rcUVdWA==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/react-overlays/-/react-overlays-5.1.1.tgz",
+      "integrity": "sha512-eCN2s2/+GVZzpnId4XVWtvDPYYBD2EtOGP74hE+8yDskPzFy9+pV1H3ZZihxuRdEbQzzacySaaDkR7xE0ydl4Q==",
       "requires": {
         "@babel/runtime": "^7.13.8",
         "@popperjs/core": "^2.8.6",
@@ -19296,9 +19277,9 @@
       }
     },
     "react-remove-scroll": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.4.2.tgz",
-      "integrity": "sha512-mMSIZYQF3jS2uRJXeFDRaVGA+BGs/hIryV64YUKsHFtpgwZloOUcdu0oW8K6OU8uLHt/kM5d0lUZbdpIVwgXtQ==",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.4.3.tgz",
+      "integrity": "sha512-lGWYXfV6jykJwbFpsuPdexKKzp96f3RbvGapDSIdcyGvHb7/eqyn46C7/6h+rUzYar1j5mdU+XECITHXCKBk9Q==",
       "requires": {
         "react-remove-scroll-bar": "^2.1.0",
         "react-style-singleton": "^2.1.0",
@@ -20303,17 +20284,6 @@
         "walker": "~1.0.5"
       }
     },
-    "sanitize-html": {
-      "version": "1.27.5",
-      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-1.27.5.tgz",
-      "integrity": "sha512-M4M5iXDAUEcZKLXkmk90zSYWEtk5NH3JmojQxKxV371fnMh+x9t1rqdmXaGoyEHw3z/X/8vnFhKjGL5xFGOJ3A==",
-      "requires": {
-        "htmlparser2": "^4.1.0",
-        "lodash": "^4.17.15",
-        "parse-srcset": "^1.0.2",
-        "postcss": "^7.0.27"
-      }
-    },
     "sass": {
       "version": "1.26.11",
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.26.11.tgz",
@@ -20896,7 +20866,8 @@
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true
     },
     "source-map-loader": {
       "version": "0.2.4",
@@ -21572,6 +21543,7 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
       "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+      "dev": true,
       "requires": {
         "has-flag": "^3.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@edx/frontend-component-header": "2.2.4",
     "@edx/frontend-enterprise-catalog-search": "^2.0.7",
     "@edx/frontend-platform": "1.12.5",
-    "@edx/paragon": "14.14.1",
+    "@edx/paragon": "16.10.0",
     "@fortawesome/fontawesome-svg-core": "1.2.35",
     "@fortawesome/free-brands-svg-icons": "5.15.3",
     "@fortawesome/free-regular-svg-icons": "5.15.3",

--- a/src/components/catalogCourseInfoModal/CatalogCourseInfoModal.jsx
+++ b/src/components/catalogCourseInfoModal/CatalogCourseInfoModal.jsx
@@ -46,46 +46,42 @@ const CatalogCourseInfoModal = ({
 
           <Image className="mr-2 partner-logo-thumbnail" src={partnerLogoImageUrl} rounded />
 
-          <div className="course-info-title-container">
-            <ModalDialog.Title as="h1" className="course-info-title">
-              {courseTitle}
-            </ModalDialog.Title>
-            <ModalDialog.Title as="h6" className="course-info-partner">
-              {courseProvider}
-            </ModalDialog.Title>
-
-            <div className="course-info-associated-catalog-header">
-              <ModalDialog.Title className="associated-catalogs-text">
-                {intl.formatMessage(messages['catalogCourseInfoModal.associatedCatalogsTitle'])}
-              </ModalDialog.Title>
-              <Badge className="associated-catalog-badges-container" variant="dark">
-                {intl.formatMessage(messages['catalogCourseInfoModal.aLaCarteBadge'])}
-              </Badge>
-              { courseAssociatedCatalogs.includes(process.env.EDX_FOR_BUSINESS_UUID) && (
-                <Badge className="associated-catalog-badges-container" variant="secondary">
-                  {intl.formatMessage(messages['catalogCourseInfoModal.businessBadge'])}
-                </Badge>
-              )}
-              { courseAssociatedCatalogs.includes(process.env.EDX_FOR_ONLINE_EDU_UUID) && (
-                <Badge className="associated-catalog-badges-container" variant="secondary">
-                  {intl.formatMessage(messages['catalogCourseInfoModal.educationBadge'])}
-                </Badge>
-              )}
-            </div>
-          </div>
+          <ModalDialog.Title as="h1" className="course-info-title">
+            {courseTitle}
+          </ModalDialog.Title>
+          <ModalDialog.Title as="h6" className="course-info-partner">
+            {courseProvider}
+          </ModalDialog.Title>
 
           <div className="pricing-data-header">
             <ModalDialog.Title className="pricing-data-title">
               {intl.formatMessage(messages['catalogCourseInfoModal.pricingTitle'])}
             </ModalDialog.Title>
             <ModalDialog.Title className="pricing-data-price">
-              $
               {coursePrice}
             </ModalDialog.Title>
           </div>
         </ModalDialog.Header>
 
         <ModalDialog.Body>
+          <div className="course-info-associated-catalog-header">
+            <ModalDialog.Title className="associated-catalogs-text">
+              {intl.formatMessage(messages['catalogCourseInfoModal.associatedCatalogsTitle'])}
+            </ModalDialog.Title>
+            <Badge className="padded-catalog" variant="dark">
+              {intl.formatMessage(messages['catalogCourseInfoModal.aLaCarteBadge'])}
+            </Badge>
+            { courseAssociatedCatalogs.includes(process.env.EDX_FOR_BUSINESS_UUID) && (
+              <Badge className="business-catalog padded-catalog" variant="secondary">
+                {intl.formatMessage(messages['catalogCourseInfoModal.businessBadge'])}
+              </Badge>
+            )}
+            { courseAssociatedCatalogs.includes(process.env.EDX_FOR_ONLINE_EDU_UUID) && (
+              <Badge className="padded-catalog" variant="light">
+                {intl.formatMessage(messages['catalogCourseInfoModal.educationBadge'])}
+              </Badge>
+            )}
+          </div>
           <p className="course-info-description-title">
             {intl.formatMessage(messages['catalogCourseInfoModal.courseDescriptionTitle'])}
           </p>

--- a/src/components/catalogCourseInfoModal/CatalogCourseInfoModal.jsx
+++ b/src/components/catalogCourseInfoModal/CatalogCourseInfoModal.jsx
@@ -1,0 +1,148 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {
+  ActionRow,
+  Badge,
+  Button,
+  Hyperlink,
+  Image,
+  ModalDialog,
+  Icon,
+} from '@edx/paragon';
+import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
+
+import { Launch } from '@edx/paragon/icons';
+import messages from './CatalogCourseInfoModal.messages';
+
+const CatalogCourseInfoModal = ({
+  intl,
+  isOpen,
+  onClose,
+  courseTitle,
+  courseProvider,
+  coursePrice,
+  courseAssociatedCatalogs,
+  courseDescription,
+  partnerLogoImageUrl,
+  bannerImageUrl,
+  marketingUrl,
+}) => (
+  <>
+    <div>
+      <ModalDialog
+        title="Course Info Dialog"
+        isOpen={isOpen}
+        onClose={onClose}
+        size="xl"
+        hasCloseButton
+        isFullscreenOnMobile
+        className="course-info-modal"
+      >
+        <ModalDialog.Hero className="course-info-hero">
+          <ModalDialog.Hero.Background backgroundSrc={bannerImageUrl} />
+        </ModalDialog.Hero>
+
+        <ModalDialog.Header className="course-info-modal-header">
+
+          <Image className="mr-2 partner-logo-thumbnail" src={partnerLogoImageUrl} rounded />
+
+          <div className="course-info-title-container">
+            <ModalDialog.Title as="h1" className="course-info-title">
+              {courseTitle}
+            </ModalDialog.Title>
+            <ModalDialog.Title as="h6" className="course-info-partner">
+              {courseProvider}
+            </ModalDialog.Title>
+
+            <div className="course-info-associated-catalog-header">
+              <ModalDialog.Title className="associated-catalogs-text">
+                {intl.formatMessage(messages['catalogCourseInfoModal.associatedCatalogsTitle'])}
+              </ModalDialog.Title>
+              <Badge className="associated-catalog-badges-container" variant="dark">
+                {intl.formatMessage(messages['catalogCourseInfoModal.aLaCarteBadge'])}
+              </Badge>
+              { courseAssociatedCatalogs.includes(process.env.EDX_FOR_BUSINESS_UUID) && (
+                <Badge className="associated-catalog-badges-container" variant="secondary">
+                  {intl.formatMessage(messages['catalogCourseInfoModal.businessBadge'])}
+                </Badge>
+              )}
+              { courseAssociatedCatalogs.includes(process.env.EDX_FOR_ONLINE_EDU_UUID) && (
+                <Badge className="associated-catalog-badges-container" variant="secondary">
+                  {intl.formatMessage(messages['catalogCourseInfoModal.educationBadge'])}
+                </Badge>
+              )}
+            </div>
+          </div>
+
+          <div className="pricing-data-header">
+            <ModalDialog.Title className="pricing-data-title">
+              {intl.formatMessage(messages['catalogCourseInfoModal.pricingTitle'])}
+            </ModalDialog.Title>
+            <ModalDialog.Title className="pricing-data-price">
+              $
+              {coursePrice}
+            </ModalDialog.Title>
+          </div>
+        </ModalDialog.Header>
+
+        <ModalDialog.Body>
+          <p className="course-info-description-title">
+            {intl.formatMessage(messages['catalogCourseInfoModal.courseDescriptionTitle'])}
+          </p>
+          {/* eslint-disable-next-line react/no-danger */}
+          <div dangerouslySetInnerHTML={{ __html: courseDescription }} />
+        </ModalDialog.Body>
+
+        <ModalDialog.Footer>
+          <ActionRow>
+            <Hyperlink
+              showLaunchIcon={false}
+              varient="muted"
+              destination={marketingUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <Button className="course-info-footer-button" variant="outline-primary">
+                {intl.formatMessage(messages['catalogCourseInfoModal.moreInfoButton'])}
+                {/* Paragon Button's `iconAfter` throws errors so the icon is manually added */}
+                <Icon className="btn-icon-after" src={Launch} />
+              </Button>
+            </Hyperlink>
+            <ModalDialog.CloseButton className="course-info-footer-button" variant="dark">
+              {intl.formatMessage(messages['catalogCourseInfoModal.closeButton'])}
+            </ModalDialog.CloseButton>
+          </ActionRow>
+        </ModalDialog.Footer>
+      </ModalDialog>
+    </div>
+  </>
+);
+
+CatalogCourseInfoModal.defaultProps = {
+  isOpen: false,
+  courseAssociatedCatalogs: [],
+  courseTitle: '',
+  courseProvider: '',
+  coursePrice: '0',
+  courseDescription: '',
+  partnerLogoImageUrl: '',
+  bannerImageUrl: '',
+  marketingUrl: '',
+  onClose: () => {},
+};
+
+CatalogCourseInfoModal.propTypes = {
+  intl: intlShape.isRequired,
+  isOpen: PropTypes.bool,
+  onClose: PropTypes.func,
+  courseTitle: PropTypes.string,
+  courseProvider: PropTypes.string,
+  coursePrice: PropTypes.string,
+  courseAssociatedCatalogs: PropTypes.arrayOf(PropTypes.string),
+  courseDescription: PropTypes.string,
+  partnerLogoImageUrl: PropTypes.string,
+  bannerImageUrl: PropTypes.string,
+  marketingUrl: PropTypes.string,
+};
+
+export default injectIntl(CatalogCourseInfoModal);

--- a/src/components/catalogCourseInfoModal/CatalogCourseInfoModal.messages.js
+++ b/src/components/catalogCourseInfoModal/CatalogCourseInfoModal.messages.js
@@ -1,0 +1,46 @@
+import { defineMessages } from '@edx/frontend-platform/i18n';
+
+const messages = defineMessages({
+  'catalogCourseInfoModal.associatedCatalogsTitle': {
+    id: 'catalogCourseInfoModal.associatedCatalogsTitle',
+    defaultMessage: 'Associated catalogs',
+    description: 'Title text for the associated catalog badges.',
+  },
+  'catalogCourseInfoModal.aLaCarteBadge': {
+    id: 'catalogCourseInfoModal.aLaCarteBadge',
+    defaultMessage: 'A la carte',
+    description: 'Badge text for the `A La Carte` catalog badge.',
+  },
+  'catalogCourseInfoModal.businessBadge': {
+    id: 'catalogCourseInfoModal.businessBadge',
+    defaultMessage: 'Business',
+    description: 'Badge text for the `Business` catalog badge.',
+  },
+  'catalogCourseInfoModal.educationBadge': {
+    id: 'catalogCourseInfoModal.educationBadge',
+    defaultMessage: 'Education',
+    description: 'Badge text for the `Education` catalog badge.',
+  },
+  'catalogCourseInfoModal.pricingTitle': {
+    id: 'catalogCourseInfoModal.pricingTitle',
+    defaultMessage: 'A la carte course price',
+    description: 'Title text for the course pricing display.',
+  },
+  'catalogCourseInfoModal.moreInfoButton': {
+    id: 'catalogCourseInfoModal.moreInfoButton',
+    defaultMessage: 'View course details',
+    description: 'Button text for the more info footer button.',
+  },
+  'catalogCourseInfoModal.closeButton': {
+    id: 'catalogCourseInfoModal.closeButton',
+    defaultMessage: 'Close',
+    description: 'Button text for the `close modal` footer button.',
+  },
+  'catalogCourseInfoModal.courseDescriptionTitle': {
+    id: 'catalogCourseInfoModal.courseDescriptionTitle',
+    defaultMessage: 'About this course',
+    description: 'Modal course description title',
+  },
+});
+
+export default messages;

--- a/src/components/catalogCourseInfoModal/CatalogCourseInfoModal.test.jsx
+++ b/src/components/catalogCourseInfoModal/CatalogCourseInfoModal.test.jsx
@@ -50,7 +50,7 @@ describe('Course info modal works as expected', () => {
   });
 
   test('modal is hidden when expected', () => {
-    let defaultPropsCopy = {};
+    const defaultPropsCopy = {};
     Object.assign(defaultPropsCopy, defaultProps);
     defaultPropsCopy.isOpen = false;
     render(
@@ -61,7 +61,7 @@ describe('Course info modal works as expected', () => {
     expect(screen.queryByText(defaultProps.courseTitle)).not.toBeInTheDocument();
   });
   test('modal displays appropriate associated catalog badges', () => {
-    let defaultPropsCopy = {};
+    const defaultPropsCopy = {};
     Object.assign(defaultPropsCopy, defaultProps);
 
     const educationQueryUuid = 'test-business-query-uuid';

--- a/src/components/catalogCourseInfoModal/CatalogCourseInfoModal.test.jsx
+++ b/src/components/catalogCourseInfoModal/CatalogCourseInfoModal.test.jsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+
+import { IntlProvider } from '@edx/frontend-platform/i18n';
+import CatalogCourseInfoModal from './CatalogCourseInfoModal';
+
+const descriptionText = 'this is a description';
+// course descriptions are injected into the DOM with dangerouslySetInnerHTML
+const descriptionHtml = `<p>${descriptionText}</p>`;
+const defaultProps = {
+  isOpen: true,
+  courseTitle: 'Course Title',
+  courseProvider: 'Course Provider',
+  coursePrice: '100',
+  courseAssociatedCatalogs: [],
+  courseDescription: descriptionHtml,
+  partnerLogoImageUrl: '',
+  bannerImageUrl: '',
+  intl: {
+    formatMessage: (header) => header.defaultMessage,
+    formatDate: () => {},
+    formatTime: () => {},
+    formatRelative: () => {},
+    formatNumber: () => {},
+    formatPlural: () => {},
+    formatHTMLMessage: () => {},
+    now: () => {},
+  },
+};
+
+describe('Course info modal works as expected', () => {
+  const OLD_ENV = process.env;
+  beforeEach(() => {
+    jest.resetModules(); // Most important - it clears the cache
+    process.env = { ...OLD_ENV }; // Make a copy
+  });
+  afterAll(() => {
+    process.env = OLD_ENV; // Restore old environment
+  });
+  test('modal renders when expected', () => {
+    render(
+      <IntlProvider locale="en">
+        <CatalogCourseInfoModal {...defaultProps} />
+      </IntlProvider>,
+    );
+    expect(screen.queryByText(defaultProps.courseTitle)).toBeInTheDocument();
+    expect(screen.queryByText(defaultProps.courseProvider)).toBeInTheDocument();
+    expect(screen.queryByText(descriptionText)).toBeInTheDocument();
+  });
+
+  test('modal is hidden when expected', () => {
+    let defaultPropsCopy = {};
+    Object.assign(defaultPropsCopy, defaultProps);
+    defaultPropsCopy.isOpen = false;
+    render(
+      <IntlProvider locale="en">
+        <CatalogCourseInfoModal {...defaultPropsCopy} />
+      </IntlProvider>,
+    );
+    expect(screen.queryByText(defaultProps.courseTitle)).not.toBeInTheDocument();
+  });
+  test('modal displays appropriate associated catalog badges', () => {
+    let defaultPropsCopy = {};
+    Object.assign(defaultPropsCopy, defaultProps);
+
+    const educationQueryUuid = 'test-business-query-uuid';
+    process.env.EDX_FOR_ONLINE_EDU_UUID = educationQueryUuid;
+    defaultPropsCopy.courseAssociatedCatalogs = [educationQueryUuid];
+
+    render(
+      <IntlProvider locale="en">
+        <CatalogCourseInfoModal {...defaultPropsCopy} />
+      </IntlProvider>,
+    );
+    expect(screen.queryByText('Education')).toBeInTheDocument();
+    expect(screen.queryByText('A la carte')).toBeInTheDocument();
+    expect(screen.queryByText('Business')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/catalogSearchResults/CatalogSearchResults.jsx
+++ b/src/components/catalogSearchResults/CatalogSearchResults.jsx
@@ -97,7 +97,7 @@ export const BaseCatalogSearchResults = ({
 
   const rowClicked = (row) => {
     const rowPrice = row.original.first_enrollable_paid_seat_price;
-    const priceText = (rowPrice != null) ? rowPrice.toString() : intl.formatMessage(
+    const priceText = (rowPrice != null) ? `$${rowPrice.toString()}` : intl.formatMessage(
       messages['catalogSearchResult.table.priceNotAvailable'],
     );
     setPrice(priceText);

--- a/src/components/catalogSearchResults/CatalogSearchResults.messages.js
+++ b/src/components/catalogSearchResults/CatalogSearchResults.messages.js
@@ -21,6 +21,11 @@ const messages = defineMessages({
     defaultMessage: 'Associated catalogs',
     description: 'Table column title for associated subscription catalogs',
   },
+  'catalogSearchResult.table.priceNotAvailable': {
+    id: 'catalogSearchResults.table.priceNotAvailable',
+    defaultMessage: ' Not Available',
+    description: 'When a course price is not available, notify learners that there is no data available to display.',
+  },
 });
 
 export default messages;

--- a/src/components/catalogSearchResults/CatalogSearchResults.test.jsx
+++ b/src/components/catalogSearchResults/CatalogSearchResults.test.jsx
@@ -3,6 +3,7 @@ import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 
 import { SearchContext } from '@edx/frontend-enterprise-catalog-search';
+import { IntlProvider } from '@edx/frontend-platform/i18n';
 import {
   BaseCatalogSearchResults, NO_DATA_MESSAGE, ERROR_MESSAGE, SKELETON_DATA_TESTID,
 } from './CatalogSearchResults';
@@ -88,7 +89,9 @@ describe('Main Catalogs view works as expected', () => {
   test('all courses rendered when search results available', () => {
     render(
       <SearchDataWrapper>
-        <BaseCatalogSearchResults {...defaultProps} />
+        <IntlProvider locale="en">
+          <BaseCatalogSearchResults {...defaultProps} />
+        </IntlProvider>,
       </SearchDataWrapper>,
     );
 

--- a/src/components/catalogs/styles/_enterprise_catalogs.scss
+++ b/src/components/catalogs/styles/_enterprise_catalogs.scss
@@ -9,8 +9,6 @@
   width: 70% !important;
   left: 0% !important;
   flex-shrink: 1;
-  font-family: Inter;
-  font-style: normal;
   font-weight: 700;
   font-size: 40px !important;
   line-height: 44px !important;
@@ -23,8 +21,6 @@
   left: 0% !important;
   margin-top: 13px;
 
-  font-family: Inter;
-  font-style: normal;
   font-weight: bold;
   font-size: 32px !important;
   line-height: 36px;
@@ -39,14 +35,15 @@
   position: absolute;
   z-index: 1;
   left: 2%;
-  top: -25%;
+  top: -75px;
   width: 15%;
-  height: 39%;
-  background-color: #F9f9f9;
-  box-shadow: 0 1px 1px rgba(0,0,0,0.25),
-              0 2px 2px rgba(0,0,0,0.20),
-              0 4px 4px rgba(0,0,0,0.15),
-              0 8px 8px rgba(0,0,0,0.10);
+  height: 70%;
+  max-height: 90px;
+  background-color: $light-300;
+  box-shadow: 0 1px 1px rgba(128,128,128,.1),
+              0 1px 1px rgba(128,128,128,.1),
+              0 2px 2px rgba(128,128,128,.1),
+              0 2px 2px rgba(128,128,128,.1);
 }
 
 .pricing-data-header {
@@ -69,12 +66,6 @@
 .course-info-modal {
   position: absolute !important;
   top: 10%;
-  height: 80%;
-}
-
-.course-info-modal-header {
-  min-height: 250px;
-  display: flex;
 }
 
 .associated-catalogs-text {
@@ -85,37 +76,19 @@
 }
 
 .course-info-associated-catalog-header {
-  margin-top: 3%;
-}
-
-.associated-catalog-badges-container {
-  padding: 0.4rem 0.4rem !important;
-  font-size: 0.6rem !important;
-  font-weight: 300 !important;
-  margin-right: 6px;
-}
-
-.course-info-description-body {
-  overflow-y: scroll;
-  white-space: pre-wrap;
-  font-family: Inter;
-  font-style: normal;
-  font-weight: 400;
-  font-size: 22px !important;
+  margin-bottom: 3%;
 }
 
 .course-info-description-title {
-  font-family: Inter;
-  font-style: normal;
   font-weight: bold;
   font-weight: 700;
   font-size: 22px !important;
 }
 
 .pgn__modal-close-container {
-  background-color: #F2F3F3 !important;
+  background-color: $gray-100 !important;
   border-radius: 50% !important;
-  border: solid 1px #000000;
+  border: solid 1px $black;
 }
 
 .course-info-footer-button {
@@ -126,8 +99,7 @@
   text-align: left;
 }
 
-.course-info-title-container {
-  position: absolute;
-  top: 20%;
-  width: 90%;
+.course-info-modal-header {
+  display: flex;
+  height: auto !important;
 }

--- a/src/components/catalogs/styles/_enterprise_catalogs.scss
+++ b/src/components/catalogs/styles/_enterprise_catalogs.scss
@@ -3,3 +3,131 @@
   @extend .mb-5;
   padding: 0px 16px;
 }
+
+.course-info-title {
+  position: relative;
+  width: 70% !important;
+  left: 0% !important;
+  flex-shrink: 1;
+  font-family: Inter;
+  font-style: normal;
+  font-weight: 700;
+  font-size: 40px !important;
+  line-height: 44px !important;
+  letter-spacing: -0.02em;
+}
+
+.course-info-partner {
+  position: relative;
+  height: 36px;
+  left: 0% !important;
+  margin-top: 13px;
+
+  font-family: Inter;
+  font-style: normal;
+  font-weight: bold;
+  font-size: 32px !important;
+  line-height: 36px;
+}
+
+.course-info-hero {
+  width: 1140px !important;
+  height: 300px !important;
+}
+
+.partner-logo-thumbnail {
+  position: absolute;
+  z-index: 1;
+  left: 2%;
+  top: -25%;
+  width: 15%;
+  height: 39%;
+  background-color: #F9f9f9;
+  box-shadow: 0 1px 1px rgba(0,0,0,0.25),
+              0 2px 2px rgba(0,0,0,0.20),
+              0 4px 4px rgba(0,0,0,0.15),
+              0 8px 8px rgba(0,0,0,0.10);
+}
+
+.pricing-data-header {
+  position: absolute;
+  right: 0%;
+  top: 25%;
+}
+
+.pricing-data-title {
+  font-weight: 500;
+  font-family: 'Roboto Mono';
+  font-size: 1rem !important;
+}
+
+.pricing-data-price {
+  margin-top: 0;
+  font-size: 2.4rem !important;
+}
+
+.course-info-modal {
+  position: absolute !important;
+  top: 10%;
+  height: 80%;
+}
+
+.course-info-modal-header {
+  min-height: 250px;
+  display: flex;
+}
+
+.associated-catalogs-text {
+  font-weight: 400;
+  font-family: 'Roboto Mono';
+  font-size: 1.4rem !important;
+  margin-bottom: 4px;
+}
+
+.course-info-associated-catalog-header {
+  margin-top: 3%;
+}
+
+.associated-catalog-badges-container {
+  padding: 0.4rem 0.4rem !important;
+  font-size: 0.6rem !important;
+  font-weight: 300 !important;
+  margin-right: 6px;
+}
+
+.course-info-description-body {
+  overflow-y: scroll;
+  white-space: pre-wrap;
+  font-family: Inter;
+  font-style: normal;
+  font-weight: 400;
+  font-size: 22px !important;
+}
+
+.course-info-description-title {
+  font-family: Inter;
+  font-style: normal;
+  font-weight: bold;
+  font-weight: 700;
+  font-size: 22px !important;
+}
+
+.pgn__modal-close-container {
+  background-color: #F2F3F3 !important;
+  border-radius: 50% !important;
+  border: solid 1px #000000;
+}
+
+.course-info-footer-button {
+  border-radius: 0px !important;
+}
+
+.catalog-search-result-column-title {
+  text-align: left;
+}
+
+.course-info-title-container {
+  position: absolute;
+  top: 20%;
+  width: 90%;
+}


### PR DESCRIPTION
**WIP**

This PR:
- replaces the course title text within the search results data table to a button
- a course info modal will now appear when the course title button is clicked, displaying information specific to the row selected
    - this modal will display course title, image, partner title and logo, a la carte price, associated catalogs, course description and a hyperlink to the B2C course details page

**Course titles now buttons:**
![image](https://user-images.githubusercontent.com/67655836/132030829-d2c8b023-d28b-4409-95ee-c66b6985f414.png)

**Course info modal with large screen**
![image](https://user-images.githubusercontent.com/67655836/132030930-713e69e7-76f9-4f9d-8fde-f11907175c2c.png)

**Course info modal with small screen**
![image](https://user-images.githubusercontent.com/67655836/132031019-c7795ca8-d366-4a85-b1f5-77ed298ff869.png)
