### PR TITLE
feat: adding a price column to the search data results

### DIFF
--- a/src/components/catalogSearchResults/CatalogSearchResults.jsx
+++ b/src/components/catalogSearchResults/CatalogSearchResults.jsx
@@ -41,6 +41,7 @@ export const BaseCatalogSearchResults = ({
   const TABLE_HEADERS = {
     courseName: intl.formatMessage(messages['catalogSearchResults.table.courseName']),
     partner: intl.formatMessage(messages['catalogSearchResults.table.partner']),
+    price: intl.formatMessage(messages['catalogSearchResults.table.price']),
     catalogs: intl.formatMessage(messages['catalogSearchResults.table.catalogs']),
   };
 
@@ -91,6 +92,11 @@ export const BaseCatalogSearchResults = ({
     {
       Header: TABLE_HEADERS.partner,
       accessor: 'partners[0].name',
+    },
+    {
+      Header: TABLE_HEADERS.price,
+      accessor: 'first_enrollable_paid_seat_price',
+      Cell: ({ row }) => (row.values.first_enrollable_paid_seat_price ? `$${row.values.first_enrollable_paid_seat_price}` : null),
     },
     {
       Header: TABLE_HEADERS.catalogs,

--- a/src/components/catalogSearchResults/CatalogSearchResults.messages.js
+++ b/src/components/catalogSearchResults/CatalogSearchResults.messages.js
@@ -11,9 +11,14 @@ const messages = defineMessages({
     defaultMessage: 'Partner',
     description: 'The partner institution providing/authoring the course (ie Harvard, MIT, etc.)',
   },
+  'catalogSearchResults.table.price': {
+    id: 'catalogSearchResults.table.price',
+    defaultMessage: 'A la carte course price',
+    description: 'Table column A La Carte price for the course',
+  },
   'catalogSearchResults.table.catalogs': {
     id: 'catalogSearchResults.table.catalogs',
-    defaultMessage: 'Associated Catalogs',
+    defaultMessage: 'Associated catalogs',
     description: 'Table column title for associated subscription catalogs',
   },
 });


### PR DESCRIPTION
[Jira](https://openedx.atlassian.net/browse/ENT-4604)

description:
now that first enrollable seat price is available on algolia, we can add a la carte pricing column to the public catalog

![image](https://user-images.githubusercontent.com/67655836/132403181-1c6eee48-13fc-465a-9c4c-a63d4105e4c8.png)

current questions: is there a placeholder that we want to display for when there isn't a price available? I don't know how common it's gonna be to have an unavailable price. 