### PR TITLE
feat: adding in custom functionality for ICE

### DIFF
--- a/src/components/catalogPage/CatalogPage.jsx
+++ b/src/components/catalogPage/CatalogPage.jsx
@@ -8,7 +8,8 @@ import Hero from '../hero/Hero';
 import messages from './CatalogPage.messages';
 import CatalogSelectionDeck from '../catalogSelectionDeck/CatalogSelectionDeck';
 import {
-  AVAILABILITY_REFINEMENT, AVAILABILITY_REFINEMENT_DEFAULTS, QUERY_TITLE_REFINEMENT, TRACKING_APP_NAME,
+  AVAILABILITY_REFINEMENT, AVAILABILITY_REFINEMENT_DEFAULTS, QUERY_TITLE_REFINEMENT,
+  HIDE_CARDS_REFINEMENT, TRACKING_APP_NAME,
 } from '../../constants';
 
 const CatalogPage = ({ intl }) => {
@@ -22,6 +23,7 @@ const CatalogPage = ({ intl }) => {
   // is cohesive with those Url params the rest of the time.
   const loadedSearchParams = new URLSearchParams(window.location.search);
   let reloadPage = false;
+  let hideCards = false;
   if (config.EDX_ENTERPRISE_ALACARTE_TITLE && (!loadedSearchParams.get(QUERY_TITLE_REFINEMENT))) {
     loadedSearchParams.set(QUERY_TITLE_REFINEMENT, config.EDX_ENTERPRISE_ALACARTE_TITLE);
     reloadPage = true;
@@ -32,6 +34,9 @@ const CatalogPage = ({ intl }) => {
   }
   if (reloadPage) {
     window.location.search = loadedSearchParams.toString();
+  }
+  if (loadedSearchParams.get(HIDE_CARDS_REFINEMENT) === 'true') {
+    hideCards = true;
   }
 
   return (
@@ -55,7 +60,7 @@ const CatalogPage = ({ intl }) => {
         [...SEARCH_FACET_FILTERS, { attribute: QUERY_TITLE_REFINEMENT, title: 'Catalog Titles', noDisplay: true }]
       }
       >
-        <CatalogSelectionDeck title={intl.formatMessage(messages['catalogPage.catalogSelectionDeck.title'])} />
+        <CatalogSelectionDeck hide={hideCards} title={intl.formatMessage(messages['catalogPage.catalogSelectionDeck.title'])} />
         <EnterpriseCatalogs />
       </SearchData>
     </main>

--- a/src/components/catalogSearchResults/CatalogSearchResults.jsx
+++ b/src/components/catalogSearchResults/CatalogSearchResults.jsx
@@ -14,11 +14,23 @@ import { FormattedMessage, injectIntl, intlShape } from '@edx/frontend-platform/
 
 import CatalogCourseInfoModal from '../catalogCourseInfoModal/CatalogCourseInfoModal';
 import messages from './CatalogSearchResults.messages';
+import { HIDE_PRICE_REFINEMENT } from '../../constants';
 
 export const ERROR_MESSAGE = 'An error occured while retrieving data';
 export const NO_DATA_MESSAGE = 'There are no course results';
 
 export const SKELETON_DATA_TESTID = 'enterprise-catalog-skeleton';
+
+function formatDate(courseRun) {
+  if (courseRun) {
+    if (courseRun.start && courseRun.end) {
+      const startDate = (new Date(courseRun.start)).toLocaleDateString('default', { month: 'short', day: 'numeric', year: 'numeric' });
+      const endDate = (new Date(courseRun.end)).toLocaleDateString('default', { month: 'short', day: 'numeric', year: 'numeric' });
+      return `${startDate} - ${endDate}`;
+    }
+  }
+  return null;
+}
 /**
  * The core search results rendering component.
  *
@@ -44,6 +56,7 @@ export const BaseCatalogSearchResults = ({
     courseName: intl.formatMessage(messages['catalogSearchResults.table.courseName']),
     partner: intl.formatMessage(messages['catalogSearchResults.table.partner']),
     price: intl.formatMessage(messages['catalogSearchResults.table.price']),
+    availability: intl.formatMessage(messages['catalogSearchResults.table.availability']),
     catalogs: intl.formatMessage(messages['catalogSearchResults.table.catalogs']),
   };
 
@@ -157,9 +170,17 @@ export const BaseCatalogSearchResults = ({
       ),
     },
   ], []);
+  const availabilityColumn = {
+    Header: TABLE_HEADERS.availability,
+    accessor: 'advertised_course_run',
+    Cell: ({ row }) => (formatDate(row.values.advertised_course_run)),
+  };
 
+  // substituting the price column with the availability dates per customer request ENT-5041
   const page = refinements.page || (searchState ? searchState.page : 0);
-
+  if (HIDE_PRICE_REFINEMENT in refinements) {
+    columns[2] = availabilityColumn;
+  }
   const tableData = useMemo(() => searchResults?.hits || [], [searchResults?.hits]);
   return (
     <>

--- a/src/components/catalogSearchResults/CatalogSearchResults.messages.js
+++ b/src/components/catalogSearchResults/CatalogSearchResults.messages.js
@@ -14,7 +14,12 @@ const messages = defineMessages({
   'catalogSearchResults.table.price': {
     id: 'catalogSearchResults.table.price',
     defaultMessage: 'A la carte course price',
-    description: 'Table column A La Carte price for the course',
+    description: 'Table column A La Carte price for the course - optional column',
+  },
+  'catalogSearchResults.table.availability': {
+    id: 'catalogSearchResults.table.availability',
+    defaultMessage: 'Course Availability',
+    description: 'Table column form course availability dates - optional column',
   },
   'catalogSearchResults.table.catalogs': {
     id: 'catalogSearchResults.table.catalogs',

--- a/src/components/catalogSearchResults/CatalogSearchResults.test.jsx
+++ b/src/components/catalogSearchResults/CatalogSearchResults.test.jsx
@@ -9,6 +9,7 @@ import {
 } from './CatalogSearchResults';
 import { renderWithRouter } from '../tests/testUtils';
 import messages from './CatalogSearchResults.messages';
+import { HIDE_PRICE_REFINEMENT } from '../../constants';
 
 // Mocking this connected component so as not to have to mock the algolia Api
 const PAGINATE_ME = 'PAGINATE ME :)';
@@ -168,5 +169,22 @@ describe('Main Catalogs view works as expected', () => {
     expect(screen.queryByText(messages['catalogSearchResults.table.courseName'].defaultMessage)).toBeInTheDocument();
     expect(screen.queryByText(messages['catalogSearchResults.table.catalogs'].defaultMessage)).toBeInTheDocument();
     expect(screen.queryByText(messages['catalogSearchResults.table.partner'].defaultMessage)).toBeInTheDocument();
+    expect(screen.queryByText(messages['catalogSearchResults.table.price'].defaultMessage)).toBeInTheDocument();
+  });
+  test('refinements hide price column and show availability', () => {
+    const refinements = { refinements: { [HIDE_PRICE_REFINEMENT]: 'true' } };
+    renderWithRouter(
+      <SearchDataWrapper
+        searchContextValue={refinements}
+      >
+        <BaseCatalogSearchResults
+          {...defaultProps}
+        />
+      </SearchDataWrapper>,
+    );
+    expect(screen.queryByText(messages['catalogSearchResults.table.courseName'].defaultMessage)).toBeInTheDocument();
+    expect(screen.queryByText(messages['catalogSearchResults.table.catalogs'].defaultMessage)).toBeInTheDocument();
+    expect(screen.queryByText(messages['catalogSearchResults.table.partner'].defaultMessage)).toBeInTheDocument();
+    expect(screen.queryByText(messages['catalogSearchResults.table.availability'].defaultMessage)).toBeInTheDocument();
   });
 });

--- a/src/components/catalogSelectionDeck/CatalogSelectionDeck.jsx
+++ b/src/components/catalogSelectionDeck/CatalogSelectionDeck.jsx
@@ -11,10 +11,10 @@ const aLaCarteVariant = 'dark';
 const businessVariant = 'secondary';
 const educationVariant = 'light';
 
-const CatalogSelectionDeck = ({ intl, title }) => {
+const CatalogSelectionDeck = ({ intl, title, hide }) => {
   const config = getConfig();
   return (
-    <section className="catalog-selection-deck">
+    <section className="catalog-selection-deck" style={{ display: hide ? 'none' : 'block' }}>
       <Container size="lg">
         <h2>{title}</h2>
         <CardDeck>
@@ -49,9 +49,14 @@ const CatalogSelectionDeck = ({ intl, title }) => {
   );
 };
 
+CatalogSelectionDeck.defaultProps = {
+  hide: false,
+};
+
 CatalogSelectionDeck.propTypes = {
   title: PropTypes.string.isRequired,
   intl: intlShape.isRequired,
+  hide: PropTypes.bool,
 };
 
 export default injectIntl(CatalogSelectionDeck);

--- a/src/components/catalogs/styles/_enterprise_catalogs.scss
+++ b/src/components/catalogs/styles/_enterprise_catalogs.scss
@@ -58,7 +58,7 @@
 .pricing-data-header {
   position: absolute;
   right: 5%;
-  top: 52%;
+  top: 66%;
 }
 
 .pricing-data-title {

--- a/src/constants.js
+++ b/src/constants.js
@@ -12,3 +12,5 @@ export const TRACKING_APP_NAME = 'explore-catalog';
 export const QUERY_TITLE_REFINEMENT = 'enterprise_catalog_query_titles';
 export const AVAILABILITY_REFINEMENT = 'availability';
 export const AVAILABILITY_REFINEMENT_DEFAULTS = ['Available Now', 'Upcoming'];
+export const HIDE_CARDS_REFINEMENT = 'hide_cards';
+export const HIDE_PRICE_REFINEMENT = 'hide_price';


### PR DESCRIPTION
[ENT-5041](https://openedx.atlassian.net/browse/ENT-5041) details the custom work that Joe requested after a customer call with ICE. They wanted customization to hide the price column, replacing it with an available date column. They also wanted the opportunity to hide the catalog selection cards. The screenshot below shows the public catalog with both url parameters applied. 

The link on prod will read as `https://explore-catalog.edx.org/?enterprise_catalog_query_titles=Education&availability=Available%20Now&availability=Upcoming&hide_price=true&hide_cards=true`

<img width="978" alt="Screen Shot 2021-10-14 at 8 09 49 AM" src="https://user-images.githubusercontent.com/31229189/137314618-b70a8fd4-5c3e-4bc8-abae-a7772d5a3adc.png">
