### PR TITLE
feat: add skills section ENT-4971

### DIFF
--- a/src/components/catalogCourseInfoModal/CatalogCourseInfoModal.jsx
+++ b/src/components/catalogCourseInfoModal/CatalogCourseInfoModal.jsx
@@ -22,7 +22,7 @@ function formatDate(start, end) {
 
 const SkillsListing = ({ skillNames }) => (
   <ul className="course-info-skills-list">
-    {skillNames.map(s => <li>{s}</li>)}
+    {skillNames.slice(0, 5).map(s => <li key={`skill-name-${s}`}>{s}</li>)}
   </ul>
 );
 

--- a/src/components/catalogCourseInfoModal/CatalogCourseInfoModal.jsx
+++ b/src/components/catalogCourseInfoModal/CatalogCourseInfoModal.jsx
@@ -20,6 +20,16 @@ function formatDate(start, end) {
   return `${startDate} - ${endDate}`;
 }
 
+const SkillsListing = ({ skillNames }) => (
+  <ul className="course-info-skills-list">
+    {skillNames.map(s => <li>{s}</li>)}
+  </ul>
+);
+
+SkillsListing.propTypes = {
+  skillNames: PropTypes.arrayOf(PropTypes.string).isRequired,
+};
+
 const CatalogCourseInfoModal = ({
   intl,
   isOpen,
@@ -34,6 +44,7 @@ const CatalogCourseInfoModal = ({
   marketingUrl,
   startDate,
   endDate,
+  skillNames,
 }) => (
 
   <>
@@ -96,13 +107,12 @@ const CatalogCourseInfoModal = ({
             </p>
             {/* eslint-disable-next-line react/no-danger */}
             <div dangerouslySetInnerHTML={{ __html: courseDescription }} />
+            {(skillNames.length > 0) && (
             <div className="course-info-skills bg-light px-2 pt-2">
-              <h4>Related Skills</h4>
-              <ul className="course-info-skills-list">
-                <li>skill 1</li>
-                <li>skill 2</li>
-              </ul>
+              <h4>{intl.formatMessage(messages['catalogCourseInfoModal.relatedSkillsHeading'])}</h4>
+              <SkillsListing skillNames={skillNames} />
             </div>
+            )}
           </div>
         </ModalDialog.Body>
 
@@ -143,6 +153,7 @@ CatalogCourseInfoModal.defaultProps = {
   marketingUrl: '',
   startDate: '',
   endDate: '',
+  skillNames: [],
   onClose: () => {},
 };
 
@@ -160,6 +171,7 @@ CatalogCourseInfoModal.propTypes = {
   marketingUrl: PropTypes.string,
   startDate: PropTypes.string,
   endDate: PropTypes.string,
+  skillNames: PropTypes.arrayOf(PropTypes.string),
 };
 
 export default injectIntl(CatalogCourseInfoModal);

--- a/src/components/catalogCourseInfoModal/CatalogCourseInfoModal.jsx
+++ b/src/components/catalogCourseInfoModal/CatalogCourseInfoModal.jsx
@@ -96,6 +96,13 @@ const CatalogCourseInfoModal = ({
             </p>
             {/* eslint-disable-next-line react/no-danger */}
             <div dangerouslySetInnerHTML={{ __html: courseDescription }} />
+            <div className="course-info-skills bg-light px-2 pt-2">
+              <h4>Related Skills</h4>
+              <ul className="course-info-skills-list">
+                <li>skill 1</li>
+                <li>skill 2</li>
+              </ul>
+            </div>
           </div>
         </ModalDialog.Body>
 

--- a/src/components/catalogCourseInfoModal/CatalogCourseInfoModal.jsx
+++ b/src/components/catalogCourseInfoModal/CatalogCourseInfoModal.jsx
@@ -21,7 +21,7 @@ function formatDate(start, end) {
 }
 
 const SkillsListing = ({ skillNames }) => (
-  <ul className="course-info-skills-list">
+  <ul className="ms-0 course-info-skills-list">
     {skillNames.slice(0, 5).map(s => <li key={`skill-name-${s}`}>{s}</li>)}
   </ul>
 );
@@ -108,7 +108,7 @@ const CatalogCourseInfoModal = ({
             {/* eslint-disable-next-line react/no-danger */}
             <div dangerouslySetInnerHTML={{ __html: courseDescription }} />
             {(skillNames.length > 0) && (
-            <div className="course-info-skills bg-light px-2 pt-2">
+            <div className="course-info-skills px-2 pb-1 pt-2">
               <h4>{intl.formatMessage(messages['catalogCourseInfoModal.relatedSkillsHeading'])}</h4>
               <SkillsListing skillNames={skillNames} />
             </div>

--- a/src/components/catalogCourseInfoModal/CatalogCourseInfoModal.messages.js
+++ b/src/components/catalogCourseInfoModal/CatalogCourseInfoModal.messages.js
@@ -31,6 +31,11 @@ const messages = defineMessages({
     defaultMessage: 'Availability period: ',
     description: 'Start and end dates for course term.',
   },
+  'catalogCourseInfoModal.relatedSkillsHeading': {
+    id: 'catalogCourseInfoModal.relatedSkillsHeading',
+    defaultMessage: 'Related skills',
+    description: 'Heading of related skills section',
+  },
   'catalogCourseInfoModal.moreInfoButton': {
     id: 'catalogCourseInfoModal.moreInfoButton',
     defaultMessage: 'View course details',

--- a/src/components/catalogCourseInfoModal/CatalogCourseInfoModal.test.jsx
+++ b/src/components/catalogCourseInfoModal/CatalogCourseInfoModal.test.jsx
@@ -88,4 +88,23 @@ describe('Course info modal works as expected', () => {
     expect(screen.queryByText('A la carte')).toBeInTheDocument();
     expect(screen.queryByText('Business')).not.toBeInTheDocument();
   });
+  test('modal displays upto 5 skills list', () => {
+    const defaultPropsCopy = {
+      ...defaultProps,
+      skillNames: [...Array(20).keys()].map(i => `skill-${i}`),
+    };
+
+    render(
+      <IntlProvider locale="en">
+        <CatalogCourseInfoModal {...defaultPropsCopy} />
+      </IntlProvider>,
+    );
+    expect(screen.queryByText('skill-0')).toBeInTheDocument();
+    expect(screen.queryByText('skill-1')).toBeInTheDocument();
+    expect(screen.queryByText('skill-2')).toBeInTheDocument();
+    expect(screen.queryByText('skill-3')).toBeInTheDocument();
+    expect(screen.queryByText('skill-4')).toBeInTheDocument();
+    expect(screen.queryByText('skill-5')).not.toBeInTheDocument();
+    expect(screen.queryByText('skill-10')).not.toBeInTheDocument();
+  });
 });

--- a/src/components/catalogCourseInfoModal/CatalogCourseInfoModal.test.jsx
+++ b/src/components/catalogCourseInfoModal/CatalogCourseInfoModal.test.jsx
@@ -99,6 +99,8 @@ describe('Course info modal works as expected', () => {
         <CatalogCourseInfoModal {...defaultPropsCopy} />
       </IntlProvider>,
     );
+    expect(screen.queryByText('Related skills')).toBeInTheDocument();
+
     expect(screen.queryByText('skill-0')).toBeInTheDocument();
     expect(screen.queryByText('skill-1')).toBeInTheDocument();
     expect(screen.queryByText('skill-2')).toBeInTheDocument();
@@ -106,5 +108,17 @@ describe('Course info modal works as expected', () => {
     expect(screen.queryByText('skill-4')).toBeInTheDocument();
     expect(screen.queryByText('skill-5')).not.toBeInTheDocument();
     expect(screen.queryByText('skill-10')).not.toBeInTheDocument();
+  });
+  test('modal displays no skills listing if skills not found', () => {
+    const defaultPropsCopy = {
+      ...defaultProps,
+    };
+
+    render(
+      <IntlProvider locale="en">
+        <CatalogCourseInfoModal {...defaultPropsCopy} />
+      </IntlProvider>,
+    );
+    expect(screen.queryByText('Related skills')).not.toBeInTheDocument();
   });
 });

--- a/src/components/catalogSearchResults/CatalogSearchResults.jsx
+++ b/src/components/catalogSearchResults/CatalogSearchResults.jsx
@@ -190,6 +190,7 @@ export const BaseCatalogSearchResults = ({
   const [marketingUrl, setMarketingUrl] = useState();
   const [startDate, setStartDate] = useState();
   const [endDate, setEndDate] = useState();
+  const [skillNames, setSkillNames] = useState([]);
 
   // TODO: Feature control for Card view. Remove once cards are finalized
   const config = getConfig();
@@ -211,6 +212,7 @@ export const BaseCatalogSearchResults = ({
     setMarketingUrl(row.original.marketing_url);
     setStartDate(row.original.advertised_course_run.start);
     setEndDate(row.original.advertised_course_run.end);
+    setSkillNames(row.original.skill_names);
     open();
   };
 
@@ -285,6 +287,7 @@ export const BaseCatalogSearchResults = ({
         marketingUrl={marketingUrl}
         startDate={startDate}
         endDate={endDate}
+        skillNames={skillNames}
       />
       <div>
         { cardViewEnabled && <ViewToggle cardView={cardView} setCardView={setCardView} /> }

--- a/src/components/catalogs/styles/_enterprise_catalogs.scss
+++ b/src/components/catalogs/styles/_enterprise_catalogs.scss
@@ -49,10 +49,8 @@
   height: 70%;
   max-height: 90px;
   background-color: $light-300;
-  box-shadow: 0 1px 1px rgba(128,128,128,.1),
-              0 1px 1px rgba(128,128,128,.1),
-              0 2px 2px rgba(128,128,128,.1),
-              0 2px 2px rgba(128,128,128,.1);
+  box-shadow: 0 1px 1px rgba(128, 128, 128, 0.1), 0 1px 1px rgba(128, 128, 128, 0.1), 0 2px 2px rgba(128, 128, 128, 0.1),
+    0 2px 2px rgba(128, 128, 128, 0.1);
 }
 
 .pricing-data-header {
@@ -63,7 +61,7 @@
 
 .pricing-data-title {
   font-weight: 500;
-  font-family: 'Roboto Mono';
+  font-family: "Roboto Mono";
   font-size: 1rem !important;
 }
 
@@ -79,7 +77,7 @@
 
 .associated-catalogs-text {
   font-weight: 400;
-  font-family: 'Roboto Mono';
+  font-family: "Roboto Mono";
   font-size: 1.4rem !important;
   margin-bottom: 4px;
 }
@@ -112,4 +110,21 @@
 .course-info-modal-header {
   display: flex;
   height: auto !important;
+}
+
+.course-info-skills {
+  opacity: 80%;
+}
+
+.course-info-skills-list {
+  display: flex;
+  align-items: flex-start;
+
+  li {
+    display: inline-block;
+  }
+  li:not(:last-child):after {
+    content: "\2022";
+    margin: 0 10px;
+  }
 }

--- a/src/components/catalogs/styles/_enterprise_catalogs.scss
+++ b/src/components/catalogs/styles/_enterprise_catalogs.scss
@@ -114,11 +114,14 @@
 
 .course-info-skills {
   opacity: 80%;
+  background-color: $light-300;
 }
 
 .course-info-skills-list {
   display: flex;
   align-items: flex-start;
+  padding-inline-start: 0;
+  font-size: medium;
 
   li {
     display: inline-block;


### PR DESCRIPTION
Shows upto 5 skills taken from the 'skill_names' key in the algolia response

There is a horizontal scrollbar issue but it was there before this PR and is also in prod so not related to this PR

<img width="1234" alt="Screen Shot 2021-11-29 at 2 25 20 PM" src="https://user-images.githubusercontent.com/528166/143929896-ee0610f6-cd37-4b60-8b43-7c39f1492f1d.png">


# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
