### PR TITLE
style fixes ENT-5199

### DIFF
--- a/src/components/catalogSearchResults/CatalogSearchResults.jsx
+++ b/src/components/catalogSearchResults/CatalogSearchResults.jsx
@@ -54,7 +54,7 @@ const ViewToggle = ({ cardView, setCardView }) => {
   const selectedClassCardView = cardView ? 'hover' : '';
   const selectedClassListView = !cardView ? 'hover' : '';
   return (
-    <div className="float-right">
+    <div className="float-right pt-1">
       <IconButton
         src={GridView}
         iconAs={Icon}

--- a/src/components/catalogs/styles/_enterprise_catalogs.scss
+++ b/src/components/catalogs/styles/_enterprise_catalogs.scss
@@ -128,7 +128,6 @@
 }
 
 .course-info-skills {
-  opacity: 80%;
   background-color: $light-300;
 }
 

--- a/src/components/catalogs/styles/_enterprise_catalogs.scss
+++ b/src/components/catalogs/styles/_enterprise_catalogs.scss
@@ -85,7 +85,6 @@
   font-size: 14px;
 }
 
-
 .course-info-modal {
   position: absolute !important;
   top: 10%;
@@ -134,8 +133,7 @@
 }
 
 .course-info-skills-list {
-  display: flex;
-  align-items: flex-start;
+  display: block;
   padding-inline-start: 0;
   font-size: medium;
 
@@ -154,7 +152,7 @@
   }
   .banner {
     display: block;
-  } 
+  }
   .banner-section {
     margin-bottom: 16px;
   }


### PR DESCRIPTION
Tested locally by:

```
npm i @edx/brand@npm:@edx/brand-edx.org  # to install the edx brand theme
npm start
```

Fixes included:

[1] : skills display bullet list was wrapping text after certain screen size reduction
Basically changing display:flex to display:block for the element (including the `<ul>`) fixes this issue, it was a mistake to use `display:flex` for the `ul` since we are using block level inline elements for the `<li>` and the `ul` itself should behave like a block level element for this use case to property support the inline block elements. 


[2]: the floating button group now has a slightly higher top padding (using bootstrap `pt-1` to fix the 'too little space' issue from the top of the surrounding div. Looks like this now:

<img width="145" alt="Screen Shot 2021-12-03 at 1 33 47 PM" src="https://user-images.githubusercontent.com/528166/144654779-d6e77d97-5061-4f22-803d-dae6fedbe81d.png">



# For all changes

- [x] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [x] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots


### For issue [1], after fixes

<img width="488" alt="small screen" src="https://user-images.githubusercontent.com/528166/144654250-24f7c06a-b6eb-4da5-b0bf-076996f12504.png">
<img width="493" alt="small screen example 2" src="https://user-images.githubusercontent.com/528166/144654251-35df4618-13df-4727-824e-a2b1544025cb.png">

