### PR TITLE
fix: fix horiz scrollbar and other CSS issues ENT-5085

### DIFF
--- a/src/components/catalogPage/CatalogPage.jsx
+++ b/src/components/catalogPage/CatalogPage.jsx
@@ -49,7 +49,7 @@ const CatalogPage = ({ intl }) => {
         <span>
           <FormattedMessage
             id="catalogPage.subtitle.text"
-            defaultMessage="edX makes it easy to find the subjects, skills, programs, and course to meet your your learning needs. Work with our content experts to create a customized catalog for your orginization from any of our 3,000+ courses. Or, choose our subscription catalog for easy, flexibility, and scalability at a single, per-learner price. "
+            defaultMessage="edX makes it easy to find the subjects, skills, programs, and course to meet your your learning needs. Work with our content experts to create a customized catalog for your organization from any of our 3,000+ courses. Or, choose our subscription catalog for ease, flexibility, and scalability at a single, per-learner price. "
             description="Description of the catalog contents and navigation to other edX pages."
           />
         </span>

--- a/src/components/catalogSelectionCard/CatalogSelectionCard.jsx
+++ b/src/components/catalogSelectionCard/CatalogSelectionCard.jsx
@@ -22,7 +22,14 @@ export const CardCheckbox = ({
     }
   };
   return (
-    <Form.Radio className="catalog-selection-card" checked={isChecked} onChange={setChecked} description={labelDetail}>{label}</Form.Radio>
+    <Form.Radio
+      className="catalog-selection-card-checkbox"
+      checked={isChecked}
+      onChange={setChecked}
+      description={labelDetail}
+    >
+      {label}
+    </Form.Radio>
   );
 };
 

--- a/src/components/catalogSelectionCard/CatalogSelectionCard.scss
+++ b/src/components/catalogSelectionCard/CatalogSelectionCard.scss
@@ -1,10 +1,12 @@
-.catalog-selection-card{
-  flex-direction: row-reverse;
+.catalog-selection-card-checkbox {
   display: flex;
+  flex-direction: row-reverse;
   justify-content: space-between;
-  .pgn__form-checkbox-input{
-    margin: 0;
+  overflow-wrap: anywhere; /* this allows word breaking to avoid weird layout in certain sizes */
+
+  & .pgn__form-radio-input {
+    /* disables the dynamic resizing of the radio boxes */
+    flex-grow: 0;
+    flex-shrink: 0;
   }
 }
-
-

--- a/src/components/catalogSelectionCard/__snapshots__/CatalogSelectionCard.test.jsx.snap
+++ b/src/components/catalogSelectionCard/__snapshots__/CatalogSelectionCard.test.jsx.snap
@@ -2,7 +2,7 @@
 
 exports[`CardCheckbox is checked when title is included in the query param 1`] = `
 <div
-  className="pgn__form-radio catalog-selection-card"
+  className="pgn__form-radio catalog-selection-card-checkbox"
 >
   <input
     aria-describedby="form-field4-6"
@@ -31,7 +31,7 @@ exports[`CardCheckbox is checked when title is included in the query param 1`] =
 
 exports[`CardCheckbox renders a checkbox and label 1`] = `
 <div
-  className="pgn__form-radio catalog-selection-card"
+  className="pgn__form-radio catalog-selection-card-checkbox"
 >
   <input
     checked={false}

--- a/src/components/catalogs/styles/_enterprise_catalogs.scss
+++ b/src/components/catalogs/styles/_enterprise_catalogs.scss
@@ -11,6 +11,7 @@
 
 .padded-body {
   margin: 180px 0 0 24px;
+  padding: 0em 0.9em;
 }
 
 .course-info-title {

--- a/src/components/catalogs/styles/_enterprise_catalogs.scss
+++ b/src/components/catalogs/styles/_enterprise_catalogs.scss
@@ -6,6 +6,7 @@
 
 .full-body {
   padding: 0px !important;
+  overflow-x: hidden; /* avoid horizontal scrollbar */
 }
 
 .padded-body {

--- a/src/components/catalogs/styles/_enterprise_catalogs.scss
+++ b/src/components/catalogs/styles/_enterprise_catalogs.scss
@@ -11,7 +11,7 @@
 
 .padded-body {
   margin: 180px 0 0 24px;
-  padding: 0em 0.9em;
+  padding: 0em 0.9em 0em 0em;
 }
 
 .course-info-title {

--- a/src/components/catalogs/styles/_enterprise_catalogs.scss
+++ b/src/components/catalogs/styles/_enterprise_catalogs.scss
@@ -46,7 +46,8 @@
   z-index: 1;
   left: 2%;
   top: 230px;
-  width: 15%;
+  width: 12vw;
+  min-width: 200px;
   height: 70%;
   max-height: 90px;
   background-color: $light-300;

--- a/src/components/hero/Hero.jsx
+++ b/src/components/hero/Hero.jsx
@@ -1,6 +1,6 @@
 import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
 import {
-  Container, ExtraExtraLarge, ExtraLarge, ExtraSmall, Image, Large, Medium, Small,
+  Container, ExtraExtraLarge, ExtraLarge, Image, Large, Medium,
 } from '@edx/paragon';
 import PropTypes from 'prop-types';
 import React from 'react';

--- a/src/components/hero/Hero.jsx
+++ b/src/components/hero/Hero.jsx
@@ -1,46 +1,74 @@
-import {
-  ExtraLarge, Image, Large, Container,
-} from '@edx/paragon';
-import React from 'react';
-import PropTypes from 'prop-types';
 import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
-import SmallHeroImageLoRes from '../../assets/hero-image-small-lo-res.png';
-import LargeHeroImageLoRes from '../../assets/hero-image-large-lo-res.png';
-import SmallHeroImageHiRes from '../../assets/hero-image-hi-res.png';
+import {
+  Container, ExtraExtraLarge, ExtraLarge, ExtraSmall, Image, Large, Medium, Small,
+} from '@edx/paragon';
+import PropTypes from 'prop-types';
+import React from 'react';
 import LargeHeroImageHiRes from '../../assets/hero-image-144px-hi-res.png';
+import SmallHeroImageHiRes from '../../assets/hero-image-hi-res.png';
+import LargeHeroImageLoRes from '../../assets/hero-image-large-lo-res.png';
+import SmallHeroImageLoRes from '../../assets/hero-image-small-lo-res.png';
 import { Highlighted } from '../helperComponents';
 import messages from './Hero.messages';
 
-const IMAGE_WRAPPER_CLASS = 'hero__image-wrapper';
 const IMAGE_CLASS = 'hero__image';
 
-const Hero = ({ intl, text, highlight }) => (
-  <section className="hero">
-    <Container size="lg" className="hero__content">
-      <h1 className="display-1"><Highlighted text={text} highlight={highlight} /></h1>
-      <div>
-        <Large className={IMAGE_WRAPPER_CLASS}>
-          <Image
-            className={IMAGE_CLASS}
-            srcSet={`${SmallHeroImageLoRes} 1000w, ${SmallHeroImageHiRes} 2000w`}
-            src={SmallHeroImageLoRes}
-            alt={intl.formatMessage(messages['hero.image.alt'])}
-            size="33vw"
-          />
-        </Large>
-        <ExtraLarge className={IMAGE_WRAPPER_CLASS}>
-          <Image
-            className={IMAGE_CLASS}
-            srcSet={`${LargeHeroImageLoRes} 1000w, ${LargeHeroImageHiRes} 2000w`}
-            src={LargeHeroImageLoRes}
-            alt={intl.formatMessage(messages['hero.image.alt'])}
-            size="33vw"
-          />
-        </ExtraLarge>
-      </div>
-    </Container>
-  </section>
+const SmallImage = ({ alt }) => (
+  <Image
+    className={IMAGE_CLASS}
+    srcSet={`${SmallHeroImageLoRes} 1000w, ${SmallHeroImageHiRes} 2000w`}
+    src={SmallHeroImageLoRes}
+    alt={alt}
+    sizes="23vw"
+  />
 );
+SmallImage.propTypes = {
+  alt: PropTypes.string.isRequired,
+};
+
+const LargeImage = ({ alt }) => (
+  <Image
+    className={IMAGE_CLASS}
+    srcSet={`${LargeHeroImageLoRes} 1000w, ${LargeHeroImageHiRes} 2000w`}
+    src={LargeHeroImageLoRes}
+    alt={alt}
+    sizes="33vw"
+  />
+);
+LargeImage.propTypes = {
+  alt: PropTypes.string.isRequired,
+};
+
+const Hero = ({ intl, text, highlight }) => {
+  const alt = intl.formatMessage(messages['hero.image.alt']);
+  return (
+    <section className="hero">
+      <Container size="lg" className="hero__content">
+        <h1 className="display-1"><Highlighted text={text} highlight={highlight} /></h1>
+        <div>
+          <ExtraSmall>
+            <SmallImage alt={alt} />
+          </ExtraSmall>
+          <Small>
+            <SmallImage alt={alt} />
+          </Small>
+          <Large>
+            <SmallImage alt={alt} />
+          </Large>
+          <Medium>
+            <SmallImage alt={alt} />
+          </Medium>
+          <ExtraExtraLarge>
+            <LargeImage alt={alt} />
+          </ExtraExtraLarge>
+          <ExtraLarge>
+            <LargeImage alt={alt} />
+          </ExtraLarge>
+        </div>
+      </Container>
+    </section>
+  );
+};
 
 Hero.defaultProps = {
   highlight: '',

--- a/src/components/hero/Hero.jsx
+++ b/src/components/hero/Hero.jsx
@@ -46,12 +46,6 @@ const Hero = ({ intl, text, highlight }) => {
       <Container size="lg" className="hero__content">
         <h1 className="display-1"><Highlighted text={text} highlight={highlight} /></h1>
         <div>
-          <ExtraSmall>
-            <SmallImage alt={alt} />
-          </ExtraSmall>
-          <Small>
-            <SmallImage alt={alt} />
-          </Small>
           <Large>
             <SmallImage alt={alt} />
           </Large>

--- a/src/components/subheader/subheader.scss
+++ b/src/components/subheader/subheader.scss
@@ -9,16 +9,12 @@
   padding: 0px 16px;
 
   .subtitle__title {
-    @extend .h4
-  }
-  .subtitle__text {
-    max-width: 70%;
+    @extend .h4;
   }
   .info {
     color: $info-300;
   }
 }
-
 
 @include media-breakpoint-down(sm) {
   .subtitle {


### PR DESCRIPTION
[1] fix for scrollbar:
    By using hidden, we will not allow scrolling right/left. It was not fully clear to me but it looks like the sentinel divs on top and bottom (the pseudo elements) were responsible for the scrollbars, since none of the content was actually overflowing. However, this avoid the horiz scroll bars in any width

[2] fix for image size shrinkage for partner logo
instead of % (which is based on parent), using 12vw width (which is per viewport instead), and also constrain min width to the 200px size that we typically see on desktop screens. This makes image width more predictable and also no crazy shrinkages. See attached.

[3] fix for checkbox size oddity. This involved making flex-grow and flex-shrink to be 0 to disable the resizing, and also a small amount of css cleanup to only style the radio area and rename some css classes



<img width="511" alt="Screen Shot 2021-12-07 at 11 12 44 AM" src="https://user-images.githubusercontent.com/528166/145067520-da30aa06-5374-4578-8776-c3b319ca6474.png">
<img width="1311" alt="Screen Shot 2021-12-07 at 11 12 34 AM" src="https://user-images.githubusercontent.com/528166/145067530-dc9e0e3c-ab9b-4669-801e-e99265601091.png">
<img width="697" alt="Screen Shot 2021-12-07 at 11 12 21 AM" src="https://user-images.githubusercontent.com/528166/145067549-c43efd00-54ce-4925-a78e-1a49b2971edb.png">
<img width="480" alt="Screen Shot 2021-12-07 at 11 12 10 AM" src="https://user-images.githubusercontent.com/528166/145067555-38804948-b716-4e18-9f75-950b45e7a60d.png">

https://user-images.githubusercontent.com/528166/145067562-fab34826-bf49-49db-baf0-2e2a5f59595c.mov


[4] fix for hero image. 
now don't show at small, xsmall but do show image at medium widths too
also show image at extraextralarge widths (wide screens)

<img width="518" alt="Screen Shot 2021-12-08 at 4 31 00 PM" src="https://user-images.githubusercontent.com/528166/145288486-ac80d9ae-5665-47e0-bc0c-c5b9e72b7892.png">

https://user-images.githubusercontent.com/528166/145288488-2278712a-36e2-4304-8e47-8a0f15cfb9be.mov

<img width="503" alt="Screen Shot 2021-12-08 at 3 11 25 PM" src="https://user-images.githubusercontent.com/528166/145288497-0fb08e9f-e549-497e-8239-e946ec3e450e.png">


will remove draft status once the other fixes are included/verified


# For all changes

- [x] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [x] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
