### PR TITLE
fix: apply max width to partner logo

### DIFF
--- a/src/components/catalogs/styles/_enterprise_catalogs.scss
+++ b/src/components/catalogs/styles/_enterprise_catalogs.scss
@@ -65,6 +65,7 @@
   left: 2%;
   top: 230px;
   width: 12vw;
+  max-width: 200px;
   min-width: 200px;
   height: 70%;
   max-height: 90px;
@@ -79,10 +80,10 @@
   line-height: 24px;
 }
 
-// cc - course card 
+// cc - course card
 .cc-partner-logo {
   left: 5%;
-  height: auto; 
+  height: auto;
   object-fit: cover;
   position: absolute;
   z-index: 1;
@@ -93,7 +94,7 @@
     0 2px 2px rgba(128, 128, 128, 0.1);
 }
 .cc-course-image {
-  height: 100px; 
+  height: 100px;
   object-fit: cover;
   width: auto;
 }
@@ -116,7 +117,7 @@
 .banner-section {
   margin-right: 16px;
   line-height: 24px;
-  color: $primary-300
+  color: $primary-300;
 }
 
 .slash {


### PR DESCRIPTION
Max width (the width used is 12vw which works great, but except at large/small screens). We already have min width for small screens. We need max width to avoid overstretchin' on wider screens :)

(alternative would have been to just use a fixed with, but I think 12vw works better by giving us just enough stretching in medium widths - I could be contested on this decision and I will listen!)

Attached before and after views on a wide screen 

also tested with small widths (no change expected for that case since I am only changing max width). Min width is already in place

## After Fix
<img width="1183" alt="after" src="https://user-images.githubusercontent.com/528166/146212314-6d085a2d-49ff-4aac-b785-67f3d68ca191.png">


## Before fix
<img width="1168" alt="before" src="https://user-images.githubusercontent.com/528166/146212316-2529e97b-9f94-4e02-8dec-7d3dfe6d3135.png">


# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [x] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
