### PR TITLE
feat: make image load whether it's a string or an object with a 'src' field

### DIFF
--- a/src/components/catalogCourseInfoModal/CatalogCourseInfoModal.jsx
+++ b/src/components/catalogCourseInfoModal/CatalogCourseInfoModal.jsx
@@ -142,10 +142,15 @@ const CourseDisplayForProgram = ({ course }) => {
   const { image, title, short_description: desc } = course;
   // TODO: we can change it to just image once catalog server is updated
   // currently image is coming out as { src: 'url' }, instead  we can just go with image: 'url'
+  // the following hack can go away after that.
+  let imageSrc = image;
+  if (typeof image === 'object' && 'src' in image) {
+    imageSrc = image.src;
+  }
   return (
     <div className="d-flex">
       <div className="mr-2">
-        <Image className="mr-2 course-info-modal-course-thumbnail" src={image.src} rounded />
+        <Image className="mr-2 course-info-modal-course-thumbnail" src={imageSrc} rounded />
       </div>
       <div className="ml-1 mr-1">
         <h3>{title}</h3>

--- a/src/components/catalogCourseInfoModal/CatalogCourseInfoModal.jsx
+++ b/src/components/catalogCourseInfoModal/CatalogCourseInfoModal.jsx
@@ -140,10 +140,12 @@ CourseModal.propTypes = {
 
 const CourseDisplayForProgram = ({ course }) => {
   const { image, title, short_description: desc } = course;
+  // TODO: we can change it to just image once catalog server is updated
+  // currently image is coming out as { src: 'url' }, instead  we can just go with image: 'url'
   return (
     <div className="d-flex">
       <div className="mr-2">
-        <Image className="mr-2 course-info-modal-course-thumbnail" src={image} rounded />
+        <Image className="mr-2 course-info-modal-course-thumbnail" src={image.src} rounded />
       </div>
       <div className="ml-1 mr-1">
         <h3>{title}</h3>


### PR DESCRIPTION
catalog server should have indexed image as string.. instead it currently does image: { src }

this change makes it handle both cases so we can render the program image correctly despite algolia state

we can undo this change once catalog server is updated to index image field as just a string instead

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
