### PR TITLE
fix: pass the correct facets in on the main view

### DIFF
--- a/src/components/catalogSearchResults/CatalogSearchResults.jsx
+++ b/src/components/catalogSearchResults/CatalogSearchResults.jsx
@@ -327,10 +327,9 @@ export const BaseCatalogSearchResults = ({
       )}
       {preview && isCourseType && (searchResults?.nbHits !== 0) && (
         <span className="landing-page-download">
-          {
-            // eslint-disable-next-line no-underscore-dangle
-            <DownloadCsvButton facets={searchResults?._state.disjunctiveFacetsRefinements} query={inputQuery} />
-          }
+            {
+              // eslint-disable-next-line no-underscore-dangle
+            }<DownloadCsvButton facets={searchResults?._state.disjunctiveFacetsRefinements} query={inputQuery} />
         </span>
       )}
       <div className="clearfix" />

--- a/src/components/catalogSearchResults/CatalogSearchResults.jsx
+++ b/src/components/catalogSearchResults/CatalogSearchResults.jsx
@@ -327,10 +327,10 @@ export const BaseCatalogSearchResults = ({
       )}
       {preview && isCourseType && (searchResults?.nbHits !== 0) && (
         <span className="landing-page-download">
-          <DownloadCsvButton
-            facets={searchResults?._state.disjunctiveFacetsRefinements}
-            query={inputQuery}
-          />
+          {
+            // eslint-disable-next-line no-underscore-dangle
+            <DownloadCsvButton facets={searchResults?._state.disjunctiveFacetsRefinements} query={inputQuery} />
+          }
         </span>
       )}
       <div className="clearfix" />

--- a/src/components/catalogSearchResults/CatalogSearchResults.jsx
+++ b/src/components/catalogSearchResults/CatalogSearchResults.jsx
@@ -328,7 +328,7 @@ export const BaseCatalogSearchResults = ({
       {preview && isCourseType && (searchResults?.nbHits !== 0) && (
         <span className="landing-page-download">
           <DownloadCsvButton
-            facets={searchResults?.disjunctiveFacetsRefinements}
+            facets={searchResults?._state.disjunctiveFacetsRefinements}
             query={inputQuery}
           />
         </span>


### PR DESCRIPTION
# Description

- when using the new programs-enabled-view, i noticed this error when trying to download from the main page

![Screen Shot 2022-02-14 at 4 54 26 PM](https://user-images.githubusercontent.com/31442/153955237-2fdb0c18-1a4a-4753-b0a2-6ee33a057009.png)

- but it worked after clicking into a content type specific view via `show`
- I noticed a difference in the way `DownloadCsvButton` was passed `facets`

![Screen Shot 2022-02-14 at 5 03 26 PM](https://user-images.githubusercontent.com/31442/153955341-70ccf091-3f47-4e0a-807f-e071dc09a9be.png)

- when making the outer one match the inner i got it working locally


## Testing

- tests pass
- local click-testing passed