### PR TITLE
fix: remove significant trailing slash

### DIFF
--- a/src/data/services/EnterpriseCatalogAPIService.js
+++ b/src/data/services/EnterpriseCatalogAPIService.js
@@ -15,7 +15,7 @@ class EnterpriseCatalogApiService {
 
   static generateCsvDownloadLink(options, query) {
     const facetQuery = query ? `&query=${query}` : '';
-    const enterpriseListUrl = `${EnterpriseCatalogApiService.enterpriseCatalogServiceApiUrl}/catalog_workbook/?${qs.stringify(options)}${facetQuery}`;
+    const enterpriseListUrl = `${EnterpriseCatalogApiService.enterpriseCatalogServiceApiUrl}/catalog_workbook?${qs.stringify(options)}${facetQuery}`;
     return enterpriseListUrl;
   }
 


### PR DESCRIPTION
## Description

- changes in explore catalog routes require no trailing slash
- https://github.com/openedx/enterprise-catalog/pull/391

## Testing

- local click tests
- tested that prod works both ways
