### PR TITLE
fix: default image changes

### DIFF
--- a/src/components/catalogSearchResults/CatalogSearchResults.test.jsx
+++ b/src/components/catalogSearchResults/CatalogSearchResults.test.jsx
@@ -213,7 +213,7 @@ describe('Main Catalogs view works as expected', () => {
     expect(courseTitleInCard).toBeVisible();
 
     // course 1 image with the correct alt text
-    expect(screen.getByAltText(TEST_COURSE_NAME)).toBeVisible();
+    expect(screen.getByAltText(`${TEST_COURSE_NAME} course image`)).toBeVisible();
   });
   test('pagination component renders', () => {
     renderWithRouter(

--- a/src/components/courseCard/CourseCard.jsx
+++ b/src/components/courseCard/CourseCard.jsx
@@ -19,16 +19,16 @@ const CourseCard = ({ intl, onClick, original }) => {
   } = original;
   const rowPrice = first_enrollable_paid_seat_price;
   const priceText = rowPrice != null ? `$${rowPrice.toString()}` : 'N/A';
+  const imageSrc = (card_image_url === undefined) ? defaultCardHeader : card_image_url;
+  const altText = `${title} course image`;
+
   return (
     <Card isClickable className="course-card" tabIndex="0" onClick={() => onClick(original)}>
       <Card.ImageCap
-        src={card_image_url}
+        src={imageSrc}
         logoSrc={partners[0].logo_image_url}
-        srcAlt={title}
+        srcAlt={altText}
         logoAlt={partners[0].name}
-        onError={(e) => {
-          e.target.src = defaultCardHeader;
-        }}
       />
       <Card.Header title={title} subtitle={partners[0].name} />
       <span className="cards-spacing" />

--- a/src/components/courseCard/CourseCard.test.jsx
+++ b/src/components/courseCard/CourseCard.test.jsx
@@ -13,7 +13,7 @@ const TEST_CATALOG = ['ayylmao'];
 
 const originalData = {
   title: 'Course Title',
-  card_image_url: '',
+  card_image_url: undefined,
   partners: [{ logo_image_url: '', name: 'Course Provider' }],
   first_enrollable_paid_seat_price: 100,
   original_image_url: '',
@@ -46,7 +46,8 @@ describe('Course card works as expected', () => {
         <CourseCard {...defaultProps} />
       </IntlProvider>,
     );
-    fireEvent.error(screen.getByAltText(originalData.title));
-    await expect((screen.getByAltText(originalData.title)).src).not.toBeUndefined;
+    const imageAltText = `${originalData.title} course image`;
+    fireEvent.error(screen.getByAltText(imageAltText));
+    await expect((screen.getByAltText(imageAltText).src)).not.toBeUndefined;
   });
 });

--- a/src/components/programCard/ProgramCard.jsx
+++ b/src/components/programCard/ProgramCard.jsx
@@ -4,11 +4,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
-import {
-  Badge,
-  Icon,
-  Card,
-} from '@edx/paragon';
+import { Badge, Icon, Card } from '@edx/paragon';
 import { Program } from '@edx/paragon/icons';
 
 import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
@@ -31,17 +27,15 @@ const ProgramCard = ({
   const alaCarteRequested = enterprise_catalog_query_titles?.includes(process.env.EDX_ENTERPRISE_ALACARTE_TITLE);
   const businessCatalogRequested = enterprise_catalog_query_titles?.includes(process.env.EDX_FOR_BUSINESS_TITLE);
   const eduCatalogRequested = enterprise_catalog_query_titles?.includes(process.env.EDX_FOR_ONLINE_EDU_TITLE);
+  const imageSrc = card_image_url === undefined ? defaultCardHeader : card_image_url;
 
   return (
     <Card isClickable className="program-card" tabIndex="0" onClick={() => onClick(original)}>
       <Card.ImageCap
-        src={card_image_url}
+        src={imageSrc}
         logoSrc={authoring_organizations[0].logo_image_url}
         srcAlt={title}
         logoAlt={authoring_organizations[0].name}
-        onError={(e) => {
-          e.target.src = defaultCardHeader;
-        }}
       />
       <Card.Header
         title={title}

--- a/src/components/programCard/ProgramCard.test.jsx
+++ b/src/components/programCard/ProgramCard.test.jsx
@@ -23,7 +23,7 @@ const TEST_CATALOG = ['ayylmao'];
 
 const originalData = {
   title: 'Program Title',
-  card_image_url: '',
+  card_image_url: undefined,
   course_keys: ['edx+123', 'edx-321'],
   authoring_organizations: [{ logo_image_url: '', name: 'Course Provider' }],
   program_type: 'Professional Certificate',


### PR DESCRIPTION
I don't really understand why these changes which previously were fixed with [this ticket ](https://github.com/openedx/frontend-app-enterprise-public-catalog/pull/202)(with corresponding tests) stopped working. It might have been something with the general node changes or some formatting bug, but here's a fix with an updated test!

# For all changes

- [x] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change
<img width="316" alt="Screen Shot 2022-05-05 at 12 36 48 PM" src="https://user-images.githubusercontent.com/31229189/166970935-cb9d5950-fb4d-4163-be9c-de8b4369ace7.png">

- [x] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
