### PR TITLE
feat: Added package-lock file version check

### DIFF
--- a/.github/workflows/lockfileversion-check.yml
+++ b/.github/workflows/lockfileversion-check.yml
@@ -1,0 +1,13 @@
+#check package-lock file version
+
+name: Lockfile Version check
+
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+
+jobs:
+  version-check:
+    uses: edx/.github/.github/workflows/lockfileversion-check.yml@master


### PR DESCRIPTION
lockfileVersion for the package-lock.json generated by NPM6 was 1 but now as we've moved to Node16 and NPM8, package-lock.json should be generated using NPM8. lockfileVersion for package-lock.json generated using NPM8 is 2. So here we're going to check the lockfileVersion in package-lock.json