### PR TITLE
build: use shared browserslist config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,6 +47,7 @@
         "regenerator-runtime": "0.13.9"
       },
       "devDependencies": {
+        "@edx/browserslist-config": "1.0.0",
         "@edx/frontend-build": "^9.1.4",
         "@testing-library/jest-dom": "5.16.4",
         "@testing-library/react": "11.2.7",
@@ -4581,6 +4582,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@edx/brand-openedx/-/brand-openedx-1.1.0.tgz",
       "integrity": "sha512-ne2ZKF1r0akkt0rEzCAQAk4cTDTI2GiWCpc+T7ldQpw9X57OnUB16dKsFNe40C9uEjL5h3Ps/ZsFM5dm4cIkEQ=="
+    },
+    "node_modules/@edx/browserslist-config": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@edx/browserslist-config/-/browserslist-config-1.0.0.tgz",
+      "integrity": "sha512-gLAlpz9Y5VruxqiUBTROG7PvouIxoMc6dvhvNpXUDHRN0KEke+zBj+zJ4frL9kGbkeex273nzSazbG42hNDLrg==",
+      "dev": true
     },
     "node_modules/@edx/eslint-config": {
       "version": "2.0.0",
@@ -34044,6 +34051,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@edx/brand-openedx/-/brand-openedx-1.1.0.tgz",
       "integrity": "sha512-ne2ZKF1r0akkt0rEzCAQAk4cTDTI2GiWCpc+T7ldQpw9X57OnUB16dKsFNe40C9uEjL5h3Ps/ZsFM5dm4cIkEQ=="
+    },
+    "@edx/browserslist-config": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@edx/browserslist-config/-/browserslist-config-1.0.0.tgz",
+      "integrity": "sha512-gLAlpz9Y5VruxqiUBTROG7PvouIxoMc6dvhvNpXUDHRN0KEke+zBj+zJ4frL9kGbkeex273nzSazbG42hNDLrg==",
+      "dev": true
     },
     "@edx/eslint-config": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -7,8 +7,7 @@
     "url": "git+https://github.com/edx/frontend-app-enterprise-public-catalog.git"
   },
   "browserslist": [
-    "last 2 versions",
-    "ie 11"
+    "extends @edx/browserslist-config"
   ],
   "scripts": {
     "build": "fedx-scripts webpack",
@@ -72,6 +71,7 @@
     "regenerator-runtime": "0.13.9"
   },
   "devDependencies": {
+    "@edx/browserslist-config": "1.0.0",
     "@edx/frontend-build": "^9.1.4",
     "@testing-library/jest-dom": "5.16.4",
     "@testing-library/react": "11.2.7",


### PR DESCRIPTION
Removes custom browserslist configuration in favor of using a [shared configuration](https://github.com/edx/browserslist-config).
Removes is-es5 check in CI since ES5 was only needed for IE 11 support which is dropped. The supported browsers defined by the shared configuration all [natively support ES6](https://caniuse.com/?search=es6).
This change reduces the resultant asset bundle size.

Created this PR due to some issues in rebasing the [older PR.](https://github.com/openedx/frontend-app-enterprise-public-catalog/pull/147)
# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
