### PR TITLE
Renovate config to automate @edx name spaced minor/patch version upgrades

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,11 @@
       "matchUpdateTypes": ["minor", "patch"],
       "matchCurrentVersion": "!/^0/",
       "automerge": true
+    },
+    {
+      "matchPackagePatterns": ["@edx"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "automerge": true
     }
   ],
   "rebaseStalePrs": true


### PR DESCRIPTION
### Ticket
[Create common renovate config that automates @edx name spaced minor/patch version upgrades](https://github.com/openedx/frontend-wg/issues/116)

### What has changed
Added Renovate config to update and auto merge `@edx` name spaced minor and patch packages.
As no schedule is provided, it will create and merge renovate PRs at any time