### PR TITLE
fix: fix transifex pull translations command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ push_translations:
 
 # Pulls translations from Transifex.
 pull_translations:
-	tx pull -f --mode reviewed --languages=$(transifex_langs)
+	tx pull -f -t --mode reviewed --languages=$(transifex_langs)
 
 # This target is used by Travis.
 validate-no-uncommitted-package-lock-changes:


### PR DESCRIPTION
### Description

- `transifex` latest version requires `-t` flag with the `tx pull` command.