### PR TITLE
feat: parsing exec ed start and end date from additional metadata

### DIFF
--- a/src/components/catalogSearchResults/CatalogSearchResults.test.jsx
+++ b/src/components/catalogSearchResults/CatalogSearchResults.test.jsx
@@ -158,6 +158,10 @@ const searchResultsExecEd = {
         upgrade_deadline: 1892678399,
         pacing_type: 'self_paced',
       },
+      additional_metadata: {
+        start_date: '2020-01-24T05:00:00Z',
+        end_date: '2080-01-01T17:00:00Z',
+      },
     },
   ],
   page: 1,

--- a/src/utils/algoliaUtils.js
+++ b/src/utils/algoliaUtils.js
@@ -53,11 +53,11 @@ function mapAlgoliaObjectToExecEd(algoliaCourseObject, intl, messages) {
     full_description: courseDescription,
     original_image_url: bannerImageUrl,
     marketing_url: marketingUrl,
-    advertised_course_run: courseRun,
     upcoming_course_runs: upcomingRuns,
     skill_names: skillNames,
+    additional_metadata: additionalMetadata,
   } = algoliaCourseObject;
-  const { start: startDate, end: endDate } = courseRun;
+  const { start_date: startDate, end_date: endDate } = additionalMetadata;
   const priceText = coursePrice != null
     ? `$${coursePrice[0].price.toString()}`
     : intl.formatMessage(


### PR DESCRIPTION
Exec ed course run dates are kept in the additional metadata field.

https://2u-internal.atlassian.net/browse/ENT-6617

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
