### PR TITLE
Update transifex api from v2 to v3

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -1,7 +1,7 @@
 [main]
 host = https://www.transifex.com
 
-[edx-platform.frontend-app-enterprise-public-catalog]
+[o:open-edx:p:edx-platform:r:frontend-app-enterprise-public-catalog]
 file_filter = src/i18n/messages/<lang>.json
 source_file = src/i18n/transifex_input.json
 source_lang = en

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,10 @@
+export TRANSIFEX_RESOURCE = frontend-app-enterprise-public-catalog
 transifex_resource = frontend-app-enterprise-public-catalog
 transifex_langs = "ar,fr,es_419,zh_CN"
 
 transifex_utils = ./node_modules/.bin/transifex-utils.js
 i18n = ./src/i18n
 transifex_input = $(i18n)/transifex_input.json
-tx_url1 = https://www.transifex.com/api/2/project/edx-platform/resource/$(transifex_resource)/translation/en/strings/
-tx_url2 = https://www.transifex.com/api/2/project/edx-platform/resource/$(transifex_resource)/source/
 
 # This directory must match .babelrc .
 transifex_temp = ./temp/babel-plugin-react-intl
@@ -38,11 +37,11 @@ push_translations:
 	# Pushing strings to Transifex...
 	tx push -s
 	# Fetching hashes from Transifex...
-	./node_modules/reactifex/bash_scripts/get_hashed_strings.sh $(tx_url1)
+	./node_modules/@edx/reactifex/bash_scripts/get_hashed_strings_v3.sh
 	# Writing out comments to file...
-	$(transifex_utils) $(transifex_temp) --comments
+	$(transifex_utils) $(transifex_temp) --comments --v3-scripts-path
 	# Pushing comments to Transifex...
-	./node_modules/reactifex/bash_scripts/put_comments.sh $(tx_url2)
+	./node_modules/@edx/reactifex/bash_scripts/put_comments_v3.sh
 
 # Pulls translations from Transifex.
 pull_translations:

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
 export TRANSIFEX_RESOURCE = frontend-app-enterprise-public-catalog
-transifex_resource = frontend-app-enterprise-public-catalog
 transifex_langs = "ar,fr,es_419,zh_CN"
 
 transifex_utils = ./node_modules/.bin/transifex-utils.js

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,6 +50,7 @@
       "devDependencies": {
         "@edx/browserslist-config": "^1.1.0",
         "@edx/frontend-build": "12.3.0",
+        "@edx/reactifex": "^2.1.1",
         "@testing-library/jest-dom": "5.16.5",
         "@testing-library/react": "11.2.7",
         "@testing-library/react-hooks": "7.0.2",
@@ -57,8 +58,7 @@
         "glob": "7.2.3",
         "husky": "6.0.0",
         "jest": "24.9.0",
-        "prettier": "2.8.4",
-        "reactifex": "1.1.1"
+        "prettier": "2.8.4"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -3071,6 +3071,81 @@
       "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
       "bin": {
         "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/@edx/reactifex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@edx/reactifex/-/reactifex-2.1.1.tgz",
+      "integrity": "sha512-A/DfCPsNNRuWhhWCquInlfG6Pi//qcxAi0P2jY/UeOVAHoOLkA3L328UtHEuoZbncXT2E1H1EDlpfNrovo/nng==",
+      "dev": true,
+      "dependencies": {
+        "axios": "^0.21.1",
+        "yargs": "^17.1.1"
+      },
+      "bin": {
+        "edx_reactifex": "main.js"
+      }
+    },
+    "node_modules/@edx/reactifex/node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@edx/reactifex/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@edx/reactifex/node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@edx/reactifex/node_modules/yargs": {
+      "version": "17.7.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.1.tgz",
+      "integrity": "sha512-cwiTb08Xuv5fqF4AovYacTFNxk62th7LKJ6BL9IGUpTJrWoU7/7WdQGTP2SjKf1dUNBGzDd28p/Yfs/GI6JrLw==",
+      "dev": true,
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@edx/reactifex/node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@emotion/cache": {
@@ -6795,7 +6870,6 @@
       "version": "0.21.4",
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
       "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
-      "peer": true,
       "dependencies": {
         "follow-redirects": "^1.14.0"
       }
@@ -24990,15 +25064,6 @@
         "react-dom": ">=16.6.0"
       }
     },
-    "node_modules/reactifex": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/reactifex/-/reactifex-1.1.1.tgz",
-      "integrity": "sha512-HH2N/b5tRxh7ypIgCRsiBl/CTxRkTEPf9DhIstaM6hne4WiwM5/bBbWuvVlRZc/i3FdqZED3pZ//6n4mtxma4w==",
-      "dev": true,
-      "bin": {
-        "reactifex": "main.js"
-      }
-    },
     "node_modules/readable-stream": {
       "version": "2.3.7",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
@@ -31163,6 +31228,65 @@
         }
       }
     },
+    "@edx/reactifex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@edx/reactifex/-/reactifex-2.1.1.tgz",
+      "integrity": "sha512-A/DfCPsNNRuWhhWCquInlfG6Pi//qcxAi0P2jY/UeOVAHoOLkA3L328UtHEuoZbncXT2E1H1EDlpfNrovo/nng==",
+      "dev": true,
+      "requires": {
+        "axios": "^0.21.1",
+        "yargs": "^17.1.1"
+      },
+      "dependencies": {
+        "cliui": {
+          "version": "8.0.1",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+          "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+          "dev": true,
+          "requires": {
+            "string-width": "^4.2.0",
+            "strip-ansi": "^6.0.1",
+            "wrap-ansi": "^7.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.1"
+          }
+        },
+        "y18n": {
+          "version": "5.0.8",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+          "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+          "dev": true
+        },
+        "yargs": {
+          "version": "17.7.1",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.1.tgz",
+          "integrity": "sha512-cwiTb08Xuv5fqF4AovYacTFNxk62th7LKJ6BL9IGUpTJrWoU7/7WdQGTP2SjKf1dUNBGzDd28p/Yfs/GI6JrLw==",
+          "dev": true,
+          "requires": {
+            "cliui": "^8.0.1",
+            "escalade": "^3.1.1",
+            "get-caller-file": "^2.0.5",
+            "require-directory": "^2.1.1",
+            "string-width": "^4.2.3",
+            "y18n": "^5.0.5",
+            "yargs-parser": "^21.1.1"
+          }
+        },
+        "yargs-parser": {
+          "version": "21.1.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+          "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+          "dev": true
+        }
+      }
+    },
     "@emotion/cache": {
       "version": "10.0.29",
       "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-10.0.29.tgz",
@@ -34106,7 +34230,6 @@
       "version": "0.21.4",
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
       "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
-      "peer": true,
       "requires": {
         "follow-redirects": "^1.14.0"
       }
@@ -47763,12 +47886,6 @@
         "loose-envify": "^1.4.0",
         "prop-types": "^15.6.2"
       }
-    },
-    "reactifex": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/reactifex/-/reactifex-1.1.1.tgz",
-      "integrity": "sha512-HH2N/b5tRxh7ypIgCRsiBl/CTxRkTEPf9DhIstaM6hne4WiwM5/bBbWuvVlRZc/i3FdqZED3pZ//6n4mtxma4w==",
-      "dev": true
     },
     "readable-stream": {
       "version": "2.3.7",

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
   "devDependencies": {
     "@edx/browserslist-config": "^1.1.0",
     "@edx/frontend-build": "12.3.0",
+    "@edx/reactifex": "^2.1.1",
     "@testing-library/jest-dom": "5.16.5",
     "@testing-library/react": "11.2.7",
     "@testing-library/react-hooks": "7.0.2",
@@ -81,7 +82,6 @@
     "glob": "7.2.3",
     "husky": "6.0.0",
     "jest": "24.9.0",
-    "prettier": "2.8.4",
-    "reactifex": "1.1.1"
+    "prettier": "2.8.4"
   }
 }


### PR DESCRIPTION
**Ticket**
[Updating /api/v2 transifex endpoints](https://github.com/edx/edx-arch-experiments/issues/202)

**What has changed?**
- Update Makefile commands for new v3 transifex API
- Add edx/reactifex as a dependency

**Reference PR**
https://github.com/openedx/frontend-app-learning/pull/837