### PR TITLE
fix: wrapping catalog search results in paragon container to fit page formatting

### DIFF
--- a/src/components/PageWrapper.jsx
+++ b/src/components/PageWrapper.jsx
@@ -7,8 +7,8 @@ import { PAGE_TITLE } from '../constants';
 export const DATA_TEST_ID = 'enterprise-catalogs-content';
 
 // eslint-disable-next-line react/prop-types
-const PageWrapper = ({ children, className }) => (
-  <Container className={className}>
+const PageWrapper = ({ children, className, size }) => (
+  <Container className={className} size={size}>
     <Helmet title={PAGE_TITLE} />
     <div data-testid={DATA_TEST_ID}>{children}</div>
   </Container>
@@ -16,6 +16,7 @@ const PageWrapper = ({ children, className }) => (
 
 PageWrapper.defaultProps = {
   className: '',
+  size: undefined,
 };
 
 export default PageWrapper;

--- a/src/components/catalogs/CatalogSearch.jsx
+++ b/src/components/catalogs/CatalogSearch.jsx
@@ -220,7 +220,7 @@ const CatalogSearch = (intl) => {
   const defaultInstantSearchFilter = `${LEARNING_TYPE_REFINEMENT}:${CONTENT_TYPE_COURSE} OR ${LEARNING_TYPE_REFINEMENT}:${CONTENT_TYPE_PROGRAM} OR ${LEARNING_TYPE_REFINEMENT}:"${EXEC_ED_TITLE}"`;
 
   return (
-    <PageWrapper className="mt-3 mb-5">
+    <PageWrapper className="mt-3 mb-5" size="xl">
       <section>
         <FormattedMessage
           id="catalogs.enterpriseCatalogs.header"


### PR DESCRIPTION
With

![image](https://github.com/openedx/frontend-app-enterprise-public-catalog/assets/67655836/50111664-4707-4782-98a0-5443fac5a765)

Without

![image](https://github.com/openedx/frontend-app-enterprise-public-catalog/assets/67655836/e6d6874d-7629-4e83-b16e-10861145ef14)

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
