### PR TITLE
fix: explorer catalog download file

### DIFF
--- a/src/components/catalogSearchResults/CatalogSearchResults.jsx
+++ b/src/components/catalogSearchResults/CatalogSearchResults.jsx
@@ -373,7 +373,7 @@ export const BaseCatalogSearchResults = ({
     setNoContent(searchResults === null || searchResults?.nbHits === 0);
   }, [searchResults, setNoContent]);
 
-  const inputQuery = query.q;
+  const inputQuery = query.get('q');
 
   const dataTableActions = () => {
     if (preview || searchResults?.nbHits === 0) {


### PR DESCRIPTION
# Description
Catalog Explorer filters are not applied to the “Download Results” button.  For instance typing Excel in the search box returns returns 133 courses. When Downloading the file, all course content is there. 
[https://2u-internal.atlassian.net/browse/ENT-7297](JIRA)

# Solution
Fixed a small bug where we were trying to access the URL query parameter `q` with a dot notation instead of `.get` that resulted in a `null` value. This caused the Algolia search to retrieve all results because of the empty search string. 

[Relevant docs on MDN for URLSearchParams](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams)

# Test Plan
1. In your terminal, check out branch `knguyen2/ENT-7297`
2. Run `cd edx-repos/frontend-app-enterprise-public-catalog`
3. Run `npm run start`
4. In the search bar, type `ielts academic test preparation` and click the `Download results` button. 
![Screenshot 2023-06-28 at 9 24 31 AM](https://github.com/openedx/frontend-app-enterprise-public-catalog/assets/71999631/810ada80-6c0f-4214-9eaf-5206220533d8)
6. Verify that you only see 2 results in the downloaded spreadsheet. 

# For all changes

- [x] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
