### PR TITLE
ENT-8297: fixed incorrect badge and broken associated catalog column

### DIFF
--- a/src/components/catalogSearchResults/CatalogSearchResults.messages.js
+++ b/src/components/catalogSearchResults/CatalogSearchResults.messages.js
@@ -60,6 +60,11 @@ const messages = defineMessages({
     defaultMessage: 'Business',
     description: 'Badge text for the `Business` catalog badge.',
   },
+  'catalogSearchResults.subscriptionBadge': {
+    id: 'catalogSearchResults.subscriptionBadge',
+    defaultMessage: 'Subscription',
+    description: 'Badge text for the `Subscription` catalog badge.',
+  },
   'catalogSearchResults.educationBadge': {
     id: 'catalogSearchResults.educationBadge',
     defaultMessage: 'Education',

--- a/src/components/catalogSearchResults/associatedComponents/catalogBadges/CatalogBadges.jsx
+++ b/src/components/catalogSearchResults/associatedComponents/catalogBadges/CatalogBadges.jsx
@@ -21,7 +21,7 @@ const CatalogBadges = ({ row }) => {
         process.env.EDX_FOR_BUSINESS_TITLE,
       ) && (
         <Badge variant="secondary" className="business-catalog padded-catalog">
-          {intl.formatMessage(messages['catalogSearchResults.businessBadge'])}
+          {intl.formatMessage(messages['catalogSearchResults.subscriptionBadge'])}
         </Badge>
       )}
       {!features.CONSOLIDATE_SUBS_CATALOG

--- a/src/components/programCard/ProgramCard.jsx
+++ b/src/components/programCard/ProgramCard.jsx
@@ -76,7 +76,7 @@ const ProgramCard = ({ intl, onClick, original }) => {
           )}
           {businessCatalogRequested && (
             <Badge variant="secondary" className="padded-catalog">
-              {intl.formatMessage(messages['ProgramCard.businessBadge'])}
+              {intl.formatMessage(messages['ProgramCard.subscriptionBadge'])}
             </Badge>
           )}
           {!features.CONSOLIDATE_SUBS_CATALOG

--- a/src/components/programCard/ProgramCard.messages.jsx
+++ b/src/components/programCard/ProgramCard.messages.jsx
@@ -16,6 +16,11 @@ const messages = defineMessages({
     defaultMessage: 'Business',
     description: 'Badge text for the `Business` catalog badge.',
   },
+  'ProgramCard.subscriptionBadge': {
+    id: 'ProgramCard.subscriptionBadge',
+    defaultMessage: 'Subscription',
+    description: 'Badge text for the `Subscription` catalog badge.',
+  },
   'ProgramCard.educationBadge': {
     id: 'ProgramCard.educationBadge',
     defaultMessage: 'Education',


### PR DESCRIPTION
**Jira Ticket**: https://2u-internal.atlassian.net/browse/ENT-8297
**Description**: 
- Fixed incorrect badge. Changed it from 'Business' to 'Subscription'
- Fixed broken associated catalog column in CSV

**UI Screenshots:**
<img width="1440" alt="Screenshot 2024-02-07 at 2 31 13 PM" src="https://github.com/openedx/frontend-app-enterprise-public-catalog/assets/113524403/eff3cd15-6fcf-445d-a472-1ffc362b0b5a">
<img width="1440" alt="Screenshot 2024-02-07 at 2 33 49 PM" src="https://github.com/openedx/frontend-app-enterprise-public-catalog/assets/113524403/fa64e485-dccf-4cde-9782-4a022be3c9ef">



# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
