### PR TITLE
fix: adjusting paragon course partner logo card to not stretch/compress

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -33,3 +33,8 @@
 .program.badge {
   font-family: $font-family-monospace;
 }
+
+.course-card .pgn__card-logo-cap {
+  object-fit: scale-down;
+  object-position: center center;
+}


### PR DESCRIPTION
https://2u-internal.atlassian.net/browse/ENT-8460

new
![image](https://github.com/openedx/frontend-app-enterprise-public-catalog/assets/67655836/16e00f71-31e0-484c-b016-5fa374323b03)

old
![image](https://github.com/openedx/frontend-app-enterprise-public-catalog/assets/67655836/34d998fc-189f-457c-936a-6c5d59a47591)

we will probably want to go back and update the paragon component at the source but this fixes the issue for now

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
