### PR TITLE
feat!: atlas pull replacing transifex pull

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,24 +29,19 @@ detect_changed_source_translations:
 	# Checking for changed translations...
 	git diff --exit-code $(i18n)
 
-# Pushes translations to Transifex.  You must run make extract_translations first.
-push_translations:
-	# Pushing strings to Transifex...
-	tx push -s
-	# Fetching hashes from Transifex...
-	./node_modules/@edx/reactifex/bash_scripts/get_hashed_strings_v3.sh
-	# Writing out comments to file...
-	$(transifex_utils) $(transifex_temp) --comments --v3-scripts-path
-	# Pushing comments to Transifex...
-	./node_modules/@edx/reactifex/bash_scripts/put_comments_v3.sh
-
+# Pulls translations using atlas.
 pull_translations:
 	rm -rf src/i18n/messages
 	mkdir src/i18n/messages
 	cd src/i18n/messages \
-      && atlas pull translations/frontend-app-enterprise-public-catalog/src/i18n/messages:frontend-app-enterprise-public-catalog
+	  && atlas pull $(ATLAS_OPTIONS) \
+	           translations/frontend-component-footer/src/i18n/messages:frontend-component-footer \
+	           translations/frontend-component-header/src/i18n/messages:frontend-component-header \
+	           translations/frontend-platform/src/i18n/messages:frontend-platform \
+	           translations/paragon/src/i18n/messages:paragon \
+	           translations/frontend-app-enterprise-public-catalog/src/i18n/messages:frontend-app-enterprise-public-catalog
 
-	$(intl_imports) frontend-app-enterprise-public-catalog
+	$(intl_imports) frontend-component-header frontend-component-footer frontend-platform paragon frontend-app-enterprise-public-catalog
 
 # This target is used by Travis.
 validate-no-uncommitted-package-lock-changes:

--- a/src/i18n/index.jsx
+++ b/src/i18n/index.jsx
@@ -1,0 +1,1 @@
+export default [];

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -12,13 +12,9 @@ import { ErrorPage } from '@edx/frontend-platform/react';
 import React from 'react';
 import ReactDOM from 'react-dom';
 
-import { messages as paragonMessages } from '@edx/paragon';
-import { messages as headerMessages } from '@edx/frontend-component-header';
-import { messages as footerMessages } from '@edx/frontend-component-footer';
-
 import App from './components/app/App';
 
-import appMessages from './i18n';
+import messages from './i18n';
 
 import './index.scss';
 
@@ -52,10 +48,5 @@ initialize({
     },
     auth: () => {},
   },
-  messages: [
-    headerMessages,
-    footerMessages,
-    paragonMessages,
-    ...appMessages,
-  ],
+  messages,
 });


### PR DESCRIPTION
## Breaking change!

This change breaks the Jenkins transifex integration which has been deprecated in favor of the new GitHub Transifex App integration as part of [OEP-58](https://open-edx-proposals.readthedocs.io/en/latest/architectural-decisions/oep-0058-arch-translations-management.html#specification).

## Changes

 - Removes all direct use of `tx pull` and `tx push` commands from the micro-frontend in favor
of the [`atlas pull`](https://github.com/openedx/openedx-atlas/) command.
 - Remove source and language translations from the repositories, hence no `.json` files will be committed into the repos. 
 - `src/i18n/index.js` should export and empty array so the `make pull_translations` override it with the dynamic list of languages.

Test results
------------
 - [x] Works with French on my machine. See screenshot below.

<details><summary>Screenshot</summary>
<p>

![image](https://github.com/openedx/frontend-app-enterprise-public-catalog/assets/645156/4c3b0829-7103-4bb2-8ee0-8fc88200c36d)


</p>
</details> 

Refs
----

This pull request is part of the [FC-0012 project](https://openedx.atlassian.net/l/cp/XGS0iCcQ) which implements the [Translation Infrastructure update OEP-58](https://docs.openedx.org/en/latest/developers/concepts/oep58.html).
