### PR TITLE
[ENT-8324]: fixed some AI Curation bugs

### DIFF
--- a/src/components/aiCuration/AskXpert.jsx
+++ b/src/components/aiCuration/AskXpert.jsx
@@ -48,22 +48,22 @@ const AskXpert = ({ catalogName, onClose, onXpertData }) => {
       const defaultErrorMessage = 'An error occurred. Please try again.';
 
       if (status < 400 || status === 429) {
-        if (!XPERT_RESULT_STATUSES.includes(finalResponse.status)) {
+        if (finalResponse.status && !XPERT_RESULT_STATUSES.includes(finalResponse.status)) {
           setResults(finalResponse.result);
-          if (finalResponse.result) {
-            setShowXpertResultCard(hasNonEmptyValues(finalResponse.result));
-
-            const aggregationKeys = {
-              [CONTENT_TYPE_COURSE]: finalResponse?.result?.ocm_courses.map(item => item.aggregation_key),
-              [EXEC_ED_TITLE]: finalResponse?.result?.exec_ed_courses.map(item => item.aggregation_key),
-              [CONTENT_TYPE_PROGRAM]: finalResponse?.result?.programs.map(item => item.aggregation_key),
-            };
-
-            onXpertData(aggregationKeys); // Pass aggregationKeys to CatalogSearch
+          if (hasNonEmptyValues(finalResponse.result)) {
+            setShowXpertResultCard(finalResponse.result);
           } else {
             // Handles the scenario where request is successful but no data is returned.
             setErrorMessage('Hm, I didnt find anything. Try telling me about the subjects, jobs, or skills you are trying to train in your organization.');
           }
+          const aggregationKeys = {
+            [CONTENT_TYPE_COURSE]: finalResponse?.result?.ocm_courses.map(item => item.aggregation_key),
+            [EXEC_ED_TITLE]: finalResponse?.result?.exec_ed_courses.map(item => item.aggregation_key),
+            [CONTENT_TYPE_PROGRAM]: finalResponse?.result?.programs.map(item => item.aggregation_key),
+          };
+
+          onXpertData(aggregationKeys); // Pass aggregationKeys to CatalogSearch for Algolia filter
+
           setIsLoading(false);
           setDelay(null);
         }

--- a/src/components/aiCuration/xpertResultCard/XpertResultCard.jsx
+++ b/src/components/aiCuration/xpertResultCard/XpertResultCard.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo } from 'react';
+import React, { useState, useMemo, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import {
   Icon, Card, Stack, Form, Button, Spinner, Image,
@@ -27,8 +27,10 @@ const XpertResultCard = ({
 
   const debouncedHandleChange = debounce(async (threshold) => {
     getXpertResultsWithThreshold(taskId, threshold);
+  }, 1000);
 
-    if (xpertResultsData) {
+  useEffect(() => {
+    if (hasNonEmptyValues(xpertResultsData)) {
       setXpertResults(xpertResultsData);
       const aggregationKeys = {
         [CONTENT_TYPE_COURSE]: xpertResultsData.ocm_courses?.map(item => item.aggregation_key),
@@ -37,7 +39,8 @@ const XpertResultCard = ({
       };
       onXpertResults(aggregationKeys);
     }
-  }, 1000);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [thresholdValue, xpertResultsData]);
 
   const handleChange = async (e) => {
     const threshold = Number(e.target.value);

--- a/src/components/catalogs/CatalogSearch.jsx
+++ b/src/components/catalogs/CatalogSearch.jsx
@@ -17,6 +17,7 @@ import {
 import { Image } from '@openedx/paragon';
 import { useAlgoliaIndex } from './data/hooks';
 import PageWrapper from '../PageWrapper';
+import { getSelectedCatalogFromURL } from '../../utils/common';
 
 import {
   CONTENT_TYPE_COURSE,
@@ -26,6 +27,7 @@ import {
   NUM_RESULTS_COURSE,
   NUM_RESULTS_PROGRAM,
   NUM_RESULTS_PER_PAGE,
+  QUERY_TITLE_REFINEMENT,
 } from '../../constants';
 import CatalogSearchResults from '../catalogSearchResults/CatalogSearchResults';
 import CatalogInfoModal from '../catalogInfoModal/CatalogInfoModal';
@@ -198,12 +200,13 @@ const CatalogSearch = (intl) => {
 
   // Take a list of learning types and render a search results component for each item
   const contentToRender = (items) => {
+    const selectedCatalog = getSelectedCatalogFromURL();
     const itemsWithResultsList = items.map((item) => {
       let filters = contentData[item].filter;
 
       if (features.ENABLE_AI_CURATION) {
         if (xpertData[item]?.length > 0) {
-          filters += ` AND (${xpertData[item]?.map(key => `aggregation_key:'${key}'`).join(' OR ')})`;
+          filters += ` AND ${QUERY_TITLE_REFINEMENT}:"${selectedCatalog}" AND (${xpertData[item]?.map(key => `aggregation_key:'${key}'`).join(' OR ')})`;
         } else if (xpertData[item]?.length === 0) {
           filters = 'aggregation_key: null';
         }


### PR DESCRIPTION
### Ticket
https://2u-internal.atlassian.net/browse/ENT-8324

### Description
This PR adds fix for following bugs identified for AI Curation

```

- The system stops retrying after receiving a 429 error from the API, it should keep retyring.
- When initially tweaking the results, an error is thrown: "No course/program found matching your filter criteria. Please broaden your focus to receive results." However, it works correctly on subsequent attempts.
- Results from the selected catalog are not being included, and the selected catalog badge is also not displayed with the course/program.

```

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
