### PR TITLE
[ENT-8324] Updated broken URL & debounce mechanism to trigger API only on slider release

### DIFF
--- a/src/components/aiCuration/data/service.js
+++ b/src/components/aiCuration/data/service.js
@@ -32,7 +32,7 @@ class EnterpriseCatalogAiCurationApiService {
 
   static async getXpertResults(taskId, threshold = 0) {
     try {
-      const response = await axios.get(`${EnterpriseCatalogAiCurationApiService.enterpriseCatalogAiCurationServiceUrl}?task_id=${taskId}&&?threshold=${threshold}`);
+      const response = await axios.get(`${EnterpriseCatalogAiCurationApiService.enterpriseCatalogAiCurationServiceUrl}?task_id=${taskId}&threshold=${threshold}`);
       return {
         status: response.status,
         data: response.data,


### PR DESCRIPTION
### Ticket
https://2u-internal.atlassian.net/browse/ENT-8324

### Description
This PR updates the broken URL and debounce mechanism that triggers the tweaking API only when the user releases the slider after sliding through multiple values, preventing requests for each slider breakpoint.

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
