### PR TITLE
test: Remove support for Node 18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,9 +9,6 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node: [18, 20]
 
     steps:
       - name: Checkout
@@ -21,7 +18,7 @@ jobs:
       - name: Setup Nodejs
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node }}
+          node-version-file: '.nvmrc'
       - name: Install dependencies
         run: npm ci
       - name: Validate package-lock.json changes


### PR DESCRIPTION
### Description

Completed upgrade to Node 20 by removing the Node 18 CI check and using `.nvmrc` for version to use.

See [the tracking issue](https://github.com/openedx/frontend-app-enterprise-public-catalog/issues/438) for further information.