### PR TITLE
feat: convert download button to stateful button

### DIFF
--- a/src/components/catalogSearchResults/CatalogSearchResults.jsx
+++ b/src/components/catalogSearchResults/CatalogSearchResults.jsx
@@ -427,13 +427,15 @@ export const BaseCatalogSearchResults = ({
         />
       )}
       {preview && isCourseType && searchResults?.nbHits !== 0 && (
-        <span className="landing-page-download mt-n5 mb-2">
-          <DownloadCsvButton
-            // eslint-disable-next-line no-underscore-dangle
-            facets={searchResults?._state.disjunctiveFacetsRefinements}
-            query={inputQuery}
-          />
-        </span>
+        <div className="position-relative">
+          <span className="landing-page-download mb-2">
+            <DownloadCsvButton
+              // eslint-disable-next-line no-underscore-dangle
+              facets={searchResults?._state.disjunctiveFacetsRefinements}
+              query={inputQuery}
+            />
+          </span>
+        </div>
       )}
       <div className="preview-title">
         <p className="h2 ml-2 mt-3 mb-3">

--- a/src/components/catalogSearchResults/associatedComponents/downloadCsvButton/DownloadCsvButton.test.jsx
+++ b/src/components/catalogSearchResults/associatedComponents/downloadCsvButton/DownloadCsvButton.test.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { screen, act } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
+import { saveAs } from 'file-saver';
 
 import userEvent from '@testing-library/user-event';
 import DownloadCsvButton from './DownloadCsvButton';
@@ -8,11 +9,18 @@ import { renderWithRouter } from '../../../tests/testUtils';
 import EnterpriseCatalogApiService from '../../../../data/services/EnterpriseCatalogAPIService';
 
 // file-saver mocks
-jest.mock('file-saver', () => ({ saveAs: jest.fn() }));
+jest.mock('file-saver', () => ({
+  ...jest.requireActual('file-saver'),
+  saveAs: jest.fn(),
+}));
 // eslint-disable-next-line func-names
 global.Blob = function (content, options) {
   return { content, options };
 };
+
+const mockDate = new Date('2024-01-06T12:00:00Z');
+const mockTimestamp = mockDate.toISOString();
+global.Date = jest.fn(() => mockDate);
 
 const mockCatalogApiService = jest.spyOn(
   EnterpriseCatalogApiService,
@@ -37,6 +45,9 @@ delete global.location;
 global.location = { href: assignMock };
 
 describe('Download button', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
   test('button renders and is clickable', async () => {
     // Render the component
     renderWithRouter(<DownloadCsvButton {...defaultProps} />);
@@ -48,10 +59,17 @@ describe('Download button', () => {
       const input = screen.getByText('Download results');
       userEvent.click(input);
     });
-    expect(mockCatalogApiService).toBeCalledWith(facets, 'foo');
+    expect(mockCatalogApiService).toHaveBeenCalledWith(facets, 'foo');
   });
   test('download button url encodes queries', async () => {
     process.env.CATALOG_SERVICE_BASE_URL = 'foobar.com';
+    const mockResponse = {
+      data: 'mock-excel-data',
+      headers: {
+        'content-type': 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+      },
+    };
+    mockCatalogApiService.mockResolvedValue(mockResponse);
     // Render the component
     renderWithRouter(<DownloadCsvButton {...badQueryProps} />);
     // Expect to be in the default state
@@ -62,8 +80,17 @@ describe('Download button', () => {
       const input = screen.getByText('Download results');
       userEvent.click(input);
     });
-    const expectedWindowLocation = `${process.env.CATALOG_SERVICE_BASE_URL}/api/v1/enterprise-catalogs/catalog_workbook?availability=Available`
-      + '+Now&availability=Upcoming&query=math%20%26%20science';
-    expect(window.location.href).toEqual(expectedWindowLocation);
+    expect(mockCatalogApiService).toHaveBeenCalledTimes(1);
+    expect(mockCatalogApiService).toHaveBeenCalledWith(smallFacets, 'math & science');
+
+    expect(saveAs).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: ['mock-excel-data'],
+        options: {
+          type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+        },
+      }),
+      `Enterprise-Catalog-Export-${mockTimestamp}.xlsx`,
+    );
   });
 });

--- a/src/components/catalogs/styles/_enterprise_catalogs.scss
+++ b/src/components/catalogs/styles/_enterprise_catalogs.scss
@@ -33,9 +33,12 @@
 }
 
 .landing-page-download {
-  float: right;
-  @media only screen and (max-width: map-get($grid-breakpoints, 'md')) {
-    float: none !important;
+  position: absolute;
+  top: -60px;
+  right: 0;
+  @media only screen and (max-width: map-get($grid-breakpoints, 'xl')) {
+    position: relative;
+    top: 0;
   }
 }
 
@@ -43,6 +46,7 @@
   justify-content: space-between;
   display: flex;
   clear: right;
+  align-items: center;
 }
 
 .partner-logo-thumbnail {

--- a/src/data/services/EnterpriseCatalogAPIService.js
+++ b/src/data/services/EnterpriseCatalogAPIService.js
@@ -1,3 +1,4 @@
+import axios from 'axios';
 import { createQueryParams } from '../../utils/catalogUtils';
 
 class EnterpriseCatalogApiService {
@@ -9,7 +10,8 @@ class EnterpriseCatalogApiService {
     const enterpriseListUrl = `${
       EnterpriseCatalogApiService.enterpriseCatalogServiceApiUrl
     }/catalog_workbook?${queryParams}${facetQuery}`;
-    return enterpriseListUrl;
+
+    return axios.get(enterpriseListUrl, { responseType: 'blob' });
   }
 }
 

--- a/src/data/services/EnterpriseCatalogAPIService.test.js
+++ b/src/data/services/EnterpriseCatalogAPIService.test.js
@@ -1,17 +1,38 @@
 import '@testing-library/jest-dom/extend-expect';
-
+import axios from 'axios';
 import EnterpriseCatalogApiService from './EnterpriseCatalogAPIService';
 
-describe('generateCsvDownloadLink', () => {
-  test('correctly formats csv download link', () => {
-    const options = { enterprise_catalog_query_titles: 'test' };
-    const query = 'somequery';
-    const generatedDownloadLink = EnterpriseCatalogApiService.generateCsvDownloadLink(
-      options,
-      query,
-    );
-    expect(generatedDownloadLink).toEqual(
-      `${process.env.CATALOG_SERVICE_BASE_URL}/api/v1/enterprise-catalogs/catalog_workbook?enterprise_catalog_query_titles=test&query=${query}`,
-    );
+jest.mock('axios');
+
+describe('EnterpriseCatalogApiService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('generateCsvDownloadLink', () => {
+    it('makes correct axios GET request with query parameters', async () => {
+      const options = { enterprise_catalog_query_titles: 'test' };
+      const query = 'somequery';
+      const expectedUrl = `${process.env.CATALOG_SERVICE_BASE_URL}/api/v1/enterprise-catalogs/catalog_workbook?enterprise_catalog_query_titles=test&query=somequery`;
+
+      const mockResponse = { data: 'test-data' };
+      axios.get.mockResolvedValue(mockResponse);
+
+      const result = await EnterpriseCatalogApiService.generateCsvDownloadLink(options, query);
+
+      expect(axios.get).toHaveBeenCalledTimes(1);
+      expect(axios.get).toHaveBeenCalledWith(expectedUrl, { responseType: 'blob' });
+      expect(result).toEqual(mockResponse);
+    });
+
+    it('handles axios error', async () => {
+      const options = { enterprise_catalog_query_titles: 'test' };
+      const error = new Error('Network error');
+      axios.get.mockRejectedValue(error);
+
+      await expect(
+        EnterpriseCatalogApiService.generateCsvDownloadLink(options),
+      ).rejects.toThrow('Network error');
+    });
   });
 });


### PR DESCRIPTION
Ticket: [ENT-9740](https://2u-internal.atlassian.net/browse/ENT-9740)

### 1. Fixed the button hitbox issue caused by negative margin.

https://github.com/user-attachments/assets/cbb0ee77-6da6-4696-8451-f9d73a228945

### 2. Converted the button to a stateful button.

https://github.com/user-attachments/assets/d83925e2-6dc0-4f15-832a-2286619fa1e2

### 3. Fixed the button's overlapping issue for tablet size screens.
### 4. Center aligned the "Courses" heading with "See all" link.
### Before
![image](https://github.com/user-attachments/assets/ed296ac3-86aa-4dab-9de5-2db02f49bd31)
### After
![image](https://github.com/user-attachments/assets/4f4fb69c-cf13-4916-9e31-8660c64bd2aa)


# For all changes

- [x] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [x] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
