### PR TITLE
feat: Added toggle to switch between learner portal and edx.org links.

### DIFF
--- a/src/components/catalogSearchResults/associatedComponents/downloadCsvButton/DownloadCsvButton.jsx
+++ b/src/components/catalogSearchResults/associatedComponents/downloadCsvButton/DownloadCsvButton.jsx
@@ -2,11 +2,11 @@ import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 
 import {
-  Icon, Toast, useToggle, StatefulButton, Spinner,
+  Icon, Toast, useToggle, StatefulButton, Spinner, Form,
 } from '@openedx/paragon';
 import { Check, Close, Download } from '@openedx/paragon/icons';
 import { saveAs } from 'file-saver';
-import { useIntl } from '@edx/frontend-platform/i18n';
+import { useIntl, FormattedMessage } from '@edx/frontend-platform/i18n';
 
 import EnterpriseCatalogApiService from '../../../../data/services/EnterpriseCatalogAPIService';
 
@@ -14,6 +14,8 @@ const DownloadCsvButton = ({ facets, query }) => {
   const [isOpen, open, close] = useToggle(false);
   const [filters, setFilters] = useState();
   const [buttonState, setButtonState] = useState('default');
+  const [shouldUseLearnerPortalLinks, setShouldUseLearnerPortalLinks] = useState(false);
+  const handleChange = e => setShouldUseLearnerPortalLinks(e.target.checked);
 
   const intl = useIntl();
 
@@ -32,7 +34,7 @@ const DownloadCsvButton = ({ facets, query }) => {
     open();
     setButtonState('pending');
     EnterpriseCatalogApiService.generateCsvDownloadLink(
-      facets,
+      shouldUseLearnerPortalLinks ? { ...facets, use_learner_portal_url: shouldUseLearnerPortalLinks } : facets,
       query,
     ).then(response => {
       const blob = new Blob([response.data], {
@@ -56,40 +58,49 @@ const DownloadCsvButton = ({ facets, query }) => {
           {toastText}
         </Toast>
       )}
-      <StatefulButton
-        state={buttonState}
-        variant={buttonState === 'error' ? 'danger' : 'primary'}
-        labels={{
-          default: intl.formatMessage({
-            id: 'catalogs.catalogSearchResults.downloadCsv.button.default',
-            defaultMessage: 'Download results',
-            description: 'Label for the download button on the catalog search results page.',
-          }),
-          pending: intl.formatMessage({
-            id: 'catalogs.catalogSearchResults.downloadCsv.button.pending',
-            defaultMessage: 'Downloading results',
-            description: 'Label for the download button on the catalog search results page when the download is in progress.',
-          }),
-          complete: intl.formatMessage({
-            id: 'catalogs.catalogSearchResults.downloadCsv.button.complete',
-            defaultMessage: 'Download complete',
-            description: 'Label for the download button on the catalog search results page when the download is complete.',
-          }),
-          error: intl.formatMessage({
-            id: 'catalogs.catalogSearchResults.downloadCsv.button.error',
-            defaultMessage: 'Error',
-            description: 'Label for the download button on the catalog search results page when the download fails.',
-          }),
-        }}
-        icons={{
-          default: <Icon src={Download} />,
-          pending: <Spinner animation="border" variant="light" size="sm" />,
-          complete: <Icon src={Check} />,
-          error: <Icon src={Close} variant="light" size="sm" />,
-        }}
-        disabledStates={['disabled', 'pending']}
-        onClick={handleClick}
-      />
+      <div className="d-flex align-items-center">
+        <Form.Switch checked={shouldUseLearnerPortalLinks} onChange={handleChange} className="mr-1">
+          <FormattedMessage
+            id="catalogs.catalogSearchResults.downloadCsv.useLearnerPortalLinks"
+            defaultMessage="Use learner portal links"
+            description="Switch to toggle whether to use learner portal links in the CSV download."
+          />
+        </Form.Switch>
+        <StatefulButton
+          state={buttonState}
+          variant={buttonState === 'error' ? 'danger' : 'primary'}
+          labels={{
+            default: intl.formatMessage({
+              id: 'catalogs.catalogSearchResults.downloadCsv.button.default',
+              defaultMessage: 'Download results',
+              description: 'Label for the download button on the catalog search results page.',
+            }),
+            pending: intl.formatMessage({
+              id: 'catalogs.catalogSearchResults.downloadCsv.button.pending',
+              defaultMessage: 'Downloading results',
+              description: 'Label for the download button on the catalog search results page when the download is in progress.',
+            }),
+            complete: intl.formatMessage({
+              id: 'catalogs.catalogSearchResults.downloadCsv.button.complete',
+              defaultMessage: 'Download complete',
+              description: 'Label for the download button on the catalog search results page when the download is complete.',
+            }),
+            error: intl.formatMessage({
+              id: 'catalogs.catalogSearchResults.downloadCsv.button.error',
+              defaultMessage: 'Error',
+              description: 'Label for the download button on the catalog search results page when the download fails.',
+            }),
+          }}
+          icons={{
+            default: <Icon src={Download} />,
+            pending: <Spinner animation="border" variant="light" size="sm" />,
+            complete: <Icon src={Check} />,
+            error: <Icon src={Close} variant="light" size="sm" />,
+          }}
+          disabledStates={['disabled', 'pending']}
+          onClick={handleClick}
+        />
+      </div>
     </>
   );
 };


### PR DESCRIPTION
# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
