### PR TITLE
Replace of injectIntl with useIntl() 1/2

### DIFF
--- a/src/components/catalogInfoModal/CatalogInfoModal.jsx
+++ b/src/components/catalogInfoModal/CatalogInfoModal.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import {
   ActionRow,
@@ -8,7 +7,7 @@ import {
   ModalDialog,
   Icon,
 } from '@openedx/paragon';
-import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
+import { useIntl } from '@edx/frontend-platform/i18n';
 
 import { Launch } from '@openedx/paragon/icons';
 import messages from './CatalogInfoModal.messages';
@@ -28,7 +27,10 @@ SkillsListing.propTypes = {
 };
 
 const CourseModal = ({
-  intl, isOpen, onClose, isExecEdType, selectedCourse,
+  isOpen,
+  onClose,
+  isExecEdType,
+  selectedCourse,
 }) => {
   const {
     courseTitle,
@@ -44,6 +46,8 @@ const CourseModal = ({
     upcomingRuns,
     skillNames,
   } = selectedCourse;
+
+  const intl = useIntl();
 
   return (
     <div>
@@ -135,7 +139,6 @@ const CourseModal = ({
 };
 
 CourseModal.propTypes = {
-  intl: intlShape.isRequired,
   isOpen: PropTypes.bool.isRequired,
   onClose: PropTypes.func.isRequired,
   isExecEdType: PropTypes.bool.isRequired,
@@ -193,7 +196,9 @@ CourseDisplayForProgram.propTypes = {
 };
 
 const ProgramModal = ({
-  intl, isOpen, onClose, selectedProgram,
+  isOpen,
+  onClose,
+  selectedProgram,
 }) => {
   const {
     programTitle,
@@ -208,6 +213,7 @@ const ProgramModal = ({
     programCourses,
   } = selectedProgram;
 
+  const intl = useIntl();
   const prices = programPrices?.filter((item) => item.currency === 'USD');
   const usdPrice = prices && prices.length > 0 ? `$${prices[0].total}` : '$0';
 
@@ -313,7 +319,6 @@ const ProgramModal = ({
 };
 
 ProgramModal.propTypes = {
-  intl: intlShape.isRequired,
   isOpen: PropTypes.bool.isRequired,
   onClose: PropTypes.func.isRequired,
   selectedProgram: PropTypes.shape({
@@ -331,7 +336,6 @@ ProgramModal.propTypes = {
 };
 
 const CatalogCourseInfoModal = ({
-  intl,
   isOpen,
   onClose,
   isExecEdType,
@@ -339,6 +343,7 @@ const CatalogCourseInfoModal = ({
   selectedProgram,
   renderProgram,
 }) => {
+  const intl = useIntl();
   if (!selectedCourse && !renderProgram) {
     return null;
   }
@@ -378,7 +383,6 @@ CatalogCourseInfoModal.defaultProps = {
 
 CatalogCourseInfoModal.propTypes = {
   renderProgram: PropTypes.bool,
-  intl: intlShape.isRequired,
   isOpen: PropTypes.bool,
   onClose: PropTypes.func,
   isExecEdType: PropTypes.bool,
@@ -410,4 +414,4 @@ CatalogCourseInfoModal.propTypes = {
   }),
 };
 
-export default injectIntl(CatalogCourseInfoModal);
+export default CatalogCourseInfoModal;

--- a/src/components/catalogModalBanner/CatalogCourseModalBanner.jsx
+++ b/src/components/catalogModalBanner/CatalogCourseModalBanner.jsx
@@ -1,7 +1,6 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import { Icon } from '@openedx/paragon';
-import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
+import { useIntl } from '@edx/frontend-platform/i18n';
 
 import {
   Book, BookOpen, EventNote, MoneyOutline,
@@ -37,72 +36,75 @@ function availabilitySubtitle(start, end, upcomingRuns) {
 }
 
 const CatalogCourseModalBanner = ({
-  intl,
   coursePrice,
   courseAssociatedCatalogs,
   startDate,
   endDate,
   upcomingRuns,
   execEd,
-}) => (
-  <div className="banner my-3">
-    <div className="banner-section mx-3">
-      <div className="banner h4 mb-0">
-        <Icon className="mr-1" src={MoneyOutline} />
-        {coursePrice.split('.')[0]}
-      </div>
-      <div className="banner-subtitle small">
-        {intl.formatMessage(
-          messages['CatalogCourseModalBanner.bannerPriceText'],
-        )}
-      </div>
-    </div>
-    <div className="banner-section slash">/</div>
-    {checkSubscriptions(courseAssociatedCatalogs) && !execEd && (
-    <>
+}) => {
+  const intl = useIntl();
+
+  return (
+    <div className="banner my-3">
       <div className="banner-section mx-3">
         <div className="banner h4 mb-0">
-          <Icon className="mr-1" src={BookOpen} />
-          {intl.formatMessage(
-            messages['CatalogCourseModalBanner.bannerCatalogText'],
-          )}
-        </div>
-        <div className="banner-subtitle small">
-          {checkSubscriptions(courseAssociatedCatalogs)}
-        </div>
-      </div>
-      <div className="banner-section slash">/</div>
-    </>
-    )}
-    {execEd && (
-    <>
-      <div className="banner-section mx-3">
-        <div className="banner h4 mb-0">
-          <Icon className="mr-1" src={Book} />
-          {intl.formatMessage(
-            messages['CatalogCourseModalBanner.bannerExecEdText'],
-          )}
+          <Icon className="mr-1" src={MoneyOutline} />
+          {coursePrice.split('.')[0]}
         </div>
         <div className="banner-subtitle small">
           {intl.formatMessage(
-            messages['CatalogCourseModalBanner.bannerExecEdSubtext'],
+            messages['CatalogCourseModalBanner.bannerPriceText'],
           )}
         </div>
       </div>
       <div className="banner-section slash">/</div>
-    </>
-    )}
-    <div className="banner-section mx-3">
-      <div className="banner h4 mb-0">
-        <Icon className="mr-1" src={EventNote} />
-        {checkAvailability(startDate, endDate)}
-      </div>
-      <div className="banner-subtitle small">
-        {availabilitySubtitle(startDate, endDate, upcomingRuns)}{' '}
+      {checkSubscriptions(courseAssociatedCatalogs) && !execEd && (
+      <>
+        <div className="banner-section mx-3">
+          <div className="banner h4 mb-0">
+            <Icon className="mr-1" src={BookOpen} />
+            {intl.formatMessage(
+              messages['CatalogCourseModalBanner.bannerCatalogText'],
+            )}
+          </div>
+          <div className="banner-subtitle small">
+            {checkSubscriptions(courseAssociatedCatalogs)}
+          </div>
+        </div>
+        <div className="banner-section slash">/</div>
+      </>
+      )}
+      {execEd && (
+      <>
+        <div className="banner-section mx-3">
+          <div className="banner h4 mb-0">
+            <Icon className="mr-1" src={Book} />
+            {intl.formatMessage(
+              messages['CatalogCourseModalBanner.bannerExecEdText'],
+            )}
+          </div>
+          <div className="banner-subtitle small">
+            {intl.formatMessage(
+              messages['CatalogCourseModalBanner.bannerExecEdSubtext'],
+            )}
+          </div>
+        </div>
+        <div className="banner-section slash">/</div>
+      </>
+      )}
+      <div className="banner-section mx-3">
+        <div className="banner h4 mb-0">
+          <Icon className="mr-1" src={EventNote} />
+          {checkAvailability(startDate, endDate)}
+        </div>
+        <div className="banner-subtitle small">
+          {availabilitySubtitle(startDate, endDate, upcomingRuns)}{' '}
+        </div>
       </div>
     </div>
-  </div>
-);
+  );
+};
 
 CatalogCourseModalBanner.defaultProps = {
   coursePrice: '0',
@@ -114,7 +116,6 @@ CatalogCourseModalBanner.defaultProps = {
 };
 
 CatalogCourseModalBanner.propTypes = {
-  intl: intlShape.isRequired,
   coursePrice: PropTypes.string,
   courseAssociatedCatalogs: PropTypes.arrayOf(PropTypes.string),
   startDate: PropTypes.string,
@@ -123,4 +124,4 @@ CatalogCourseModalBanner.propTypes = {
   execEd: PropTypes.bool,
 };
 
-export default injectIntl(CatalogCourseModalBanner);
+export default CatalogCourseModalBanner;

--- a/src/components/catalogModalBanner/CatalogProgramModalBanner.jsx
+++ b/src/components/catalogModalBanner/CatalogProgramModalBanner.jsx
@@ -1,66 +1,68 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import { Icon } from '@openedx/paragon';
-import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
+import { useIntl } from '@edx/frontend-platform/i18n';
 
 import { Assignment, BookOpen, MoneyOutline } from '@openedx/paragon/icons';
 import messages from './CatalogCourseModalBanner.messages';
 import { checkSubscriptions } from '../../utils/catalogUtils';
 
 const CatalogProgramModalBanner = ({
-  intl,
   coursePrice,
   courseAssociatedCatalogs,
   courses,
-}) => (
-  <div className="banner">
-    {coursePrice !== undefined && (
-    <>
+}) => {
+  const intl = useIntl();
+
+  return (
+    <div className="banner">
+      {coursePrice !== undefined && (
+      <>
+        <div className="banner-section mx-3">
+          <div className="banner h4 mb-0">
+            <Icon className="mr-1" src={MoneyOutline} />
+            {coursePrice}
+          </div>
+          <div className="banner-subtitle small">
+            {intl.formatMessage(
+              messages['CatalogCourseModalBanner.bannerPriceTextProgram'],
+            )}
+          </div>
+        </div>
+        <div className="banner-section slash">/</div>
+      </>
+      )}
+      {courses && courses.length > 0 && (
+      <>
+        <div className="banner-section mx-3">
+          <div className="banner h4 mb-0">
+            <Icon className="mr-1" src={Assignment} />
+            {courses.length} courses
+          </div>
+          <div className="banner-subtitle small">
+            {intl.formatMessage(
+              messages['CatalogCourseModalBanner.bannerCourseText'],
+            )}
+          </div>
+        </div>
+        <div className="banner-section slash">/</div>
+      </>
+      )}
+      {checkSubscriptions(courseAssociatedCatalogs) && (
       <div className="banner-section mx-3">
         <div className="banner h4 mb-0">
-          <Icon className="mr-1" src={MoneyOutline} />
-          {coursePrice}
-        </div>
-        <div className="banner-subtitle small">
+          <Icon className="mr-1" src={BookOpen} />
           {intl.formatMessage(
-            messages['CatalogCourseModalBanner.bannerPriceTextProgram'],
+            messages['CatalogCourseModalBanner.bannerCatalogText'],
           )}
         </div>
-      </div>
-      <div className="banner-section slash">/</div>
-    </>
-    )}
-    {courses && courses.length > 0 && (
-    <>
-      <div className="banner-section mx-3">
-        <div className="banner h4 mb-0">
-          <Icon className="mr-1" src={Assignment} />
-          {courses.length} courses
-        </div>
         <div className="banner-subtitle small">
-          {intl.formatMessage(
-            messages['CatalogCourseModalBanner.bannerCourseText'],
-          )}
+          {checkSubscriptions(courseAssociatedCatalogs)}
         </div>
       </div>
-      <div className="banner-section slash">/</div>
-    </>
-    )}
-    {checkSubscriptions(courseAssociatedCatalogs) && (
-    <div className="banner-section mx-3">
-      <div className="banner h4 mb-0">
-        <Icon className="mr-1" src={BookOpen} />
-        {intl.formatMessage(
-          messages['CatalogCourseModalBanner.bannerCatalogText'],
-        )}
-      </div>
-      <div className="banner-subtitle small">
-        {checkSubscriptions(courseAssociatedCatalogs)}
-      </div>
+      )}
     </div>
-    )}
-  </div>
-);
+  );
+};
 
 CatalogProgramModalBanner.defaultProps = {
   coursePrice: '$0',
@@ -69,10 +71,9 @@ CatalogProgramModalBanner.defaultProps = {
 };
 
 CatalogProgramModalBanner.propTypes = {
-  intl: intlShape.isRequired,
   coursePrice: PropTypes.string,
   courseAssociatedCatalogs: PropTypes.arrayOf(PropTypes.string),
   courses: PropTypes.arrayOf(PropTypes.shape({})),
 };
 
-export default injectIntl(CatalogProgramModalBanner);
+export default CatalogProgramModalBanner;

--- a/src/components/catalogNoResultsDeck/CatalogNoResultsDeck.jsx
+++ b/src/components/catalogNoResultsDeck/CatalogNoResultsDeck.jsx
@@ -1,8 +1,8 @@
-import React, { useMemo } from 'react';
+import { useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { connectStateResults } from 'react-instantsearch-dom';
 
-import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
+import { useIntl } from '@edx/frontend-platform/i18n';
 import { Alert, CardView, DataTable } from '@openedx/paragon';
 
 import {
@@ -19,13 +19,13 @@ import { getSelectedCatalogFromURL } from '../../utils/common';
 const BASE_APP_URL = process.env.BASE_URL;
 
 const CatalogNoResultsDeck = ({
-  intl,
   setCardView,
   columns,
   renderCardComponent,
   contentType,
   searchResults,
 }) => {
+  const intl = useIntl();
   const tableData = useMemo(
     () => searchResults?.hits || [],
     [searchResults?.hits],
@@ -133,10 +133,9 @@ CatalogNoResultsDeck.propTypes = {
     page: PropTypes.number,
   }),
   contentType: PropTypes.string,
-  intl: intlShape.isRequired,
   setCardView: PropTypes.func,
   renderCardComponent: PropTypes.func,
   columns: PropTypes.arrayOf(PropTypes.shape({})),
 };
 
-export default connectStateResults(injectIntl(CatalogNoResultsDeck));
+export default connectStateResults(CatalogNoResultsDeck);

--- a/src/components/catalogPage/CatalogPage.jsx
+++ b/src/components/catalogPage/CatalogPage.jsx
@@ -1,9 +1,4 @@
-import React from 'react';
-import {
-  FormattedMessage,
-  injectIntl,
-  intlShape,
-} from '@edx/frontend-platform/i18n';
+import { FormattedMessage, useIntl } from '@edx/frontend-platform/i18n';
 import {
   SearchData,
   SEARCH_FACET_FILTERS,
@@ -36,7 +31,8 @@ if (
   SEARCH_FACET_FILTERS.push(learningType);
 }
 
-const CatalogPage = ({ intl }) => {
+const CatalogPage = () => {
+  const intl = useIntl();
   const location = useLocation();
   const config = getConfig();
   // Default routing:
@@ -149,8 +145,4 @@ const CatalogPage = ({ intl }) => {
   );
 };
 
-CatalogPage.propTypes = {
-  intl: intlShape.isRequired,
-};
-
-export default injectIntl(CatalogPage);
+export default CatalogPage;

--- a/src/components/catalogs/CatalogSearch.jsx
+++ b/src/components/catalogs/CatalogSearch.jsx
@@ -1,12 +1,8 @@
 /* eslint eqeqeq: "off" */
-import React, {
+import {
   useContext, useState, useMemo, useEffect,
 } from 'react';
-import {
-  FormattedMessage,
-  injectIntl,
-  intlShape,
-} from '@edx/frontend-platform/i18n';
+import { FormattedMessage, useIntl } from '@edx/frontend-platform/i18n';
 
 import { getConfig } from '@edx/frontend-platform/config';
 import { Configure, Index, InstantSearch } from 'react-instantsearch-dom';
@@ -42,7 +38,8 @@ import xpertLogo from '../../assets/edx-xpert-logo.png';
 import features from '../../config';
 import AskXpert from '../aiCuration/AskXpert';
 
-const CatalogSearch = (intl) => {
+const CatalogSearch = () => {
+  const intl = useIntl();
   const {
     refinements: {
       [LEARNING_TYPE_REFINEMENT]: learningType,
@@ -316,9 +313,4 @@ const CatalogSearch = (intl) => {
   );
 };
 
-CatalogSearch.propTypes = {
-  // eslint-disable-next-line react/no-unused-prop-types
-  intl: intlShape.isRequired,
-};
-
-export default injectIntl(CatalogSearch);
+export default CatalogSearch;


### PR DESCRIPTION
### Description
As part of the project for improvements as follow up of react-unit-test-utils, we are going to replace all usages of the deprecated `injectIntl` HOC with the `useIntl()` hook from @edx/frontend-platform/i18n. It is a very straight-forward change, in order to accomplish this we did the following changes:

- In components we have to remove the old `injectIntl`, remove intl as a prop and use the hook instead.
- In tests we need to stop using `injectIntl` and just use the desired component wrapped in a `IntlProvider` (from @edx/frontend-platform/i18n).

Files to refactor:
- src/components/catalogInfoModal/CatalogInfoModal.jsx
- src/components/catalogModalBanner/CatalogCourseModalBanner.jsx
- src/components/catalogModalBanner/CatalogProgramModalBanner.jsx
- src/components/catalogNoResultsDeck/CatalogNoResultsDeck.jsx
- src/components/catalogPage/CatalogPage.jsx
- src/components/catalogs/CatalogSearch.jsx

#### Support Information
Closes #495 
