### PR TITLE
Replace of injectIntl with useIntl() 2/2

### DIFF
--- a/src/components/catalogSearchResults/CatalogSearchResults.jsx
+++ b/src/components/catalogSearchResults/CatalogSearchResults.jsx
@@ -4,16 +4,12 @@ import {
   setRefinementAction,
   useNbHitsFromSearchResults,
 } from '@edx/frontend-enterprise-catalog-search';
-import {
-  FormattedMessage,
-  injectIntl,
-  intlShape,
-} from '@edx/frontend-platform/i18n';
+import { FormattedMessage, useIntl } from '@edx/frontend-platform/i18n';
 import {
   Alert, Badge, Button, CardView, DataTable, Skeleton,
 } from '@openedx/paragon';
 import PropTypes from 'prop-types';
-import React, {
+import {
   useCallback,
   useContext,
   useEffect,
@@ -82,7 +78,6 @@ export const SKELETON_DATA_TESTID = 'enterprise-catalog-skeleton';
  */
 
 export const BaseCatalogSearchResults = ({
-  intl,
   searchResults,
   // algolia recommends this prop instead of searching
   isSearchStalled,
@@ -93,6 +88,7 @@ export const BaseCatalogSearchResults = ({
   setNoContent,
   preview,
 }) => {
+  const intl = useIntl();
   const { algoliaIndexName, searchClient } = useAlgoliaIndex();
   const [isProgramType, setIsProgramType] = useState();
   const [isCourseType, setIsCourseType] = useState();
@@ -532,7 +528,6 @@ BaseCatalogSearchResults.defaultProps = {
 };
 
 BaseCatalogSearchResults.propTypes = {
-  intl: intlShape.isRequired,
   // from Algolia
   searchResults: PropTypes.shape({
     _state: PropTypes.shape({
@@ -562,4 +557,4 @@ BaseCatalogSearchResults.propTypes = {
   setNoContent: PropTypes.func,
 };
 
-export default connectStateResults(injectIntl(BaseCatalogSearchResults));
+export default connectStateResults(BaseCatalogSearchResults);

--- a/src/components/catalogSelectionDeck/CatalogSelectionDeck.jsx
+++ b/src/components/catalogSelectionDeck/CatalogSelectionDeck.jsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useState } from 'react';
+import { useContext, useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
@@ -10,12 +10,13 @@ import {
 import {
   breakpoints, Container, SelectableBox, useMediaQuery,
 } from '@openedx/paragon';
-import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
+import { useIntl } from '@edx/frontend-platform/i18n';
 
 import messages from './CatalogSelectionDeck.messages';
 import { QUERY_TITLE_REFINEMENT } from '../../constants';
 
-const CatalogSelectionDeck = ({ intl, title, hide }) => {
+const CatalogSelectionDeck = ({ title, hide }) => {
+  const intl = useIntl();
   const { refinements, dispatch } = useContext(SearchContext);
   const config = getConfig();
   const [value, setValue] = useState('');
@@ -72,8 +73,7 @@ CatalogSelectionDeck.defaultProps = {
 
 CatalogSelectionDeck.propTypes = {
   title: PropTypes.string.isRequired,
-  intl: intlShape.isRequired,
   hide: PropTypes.bool,
 };
 
-export default injectIntl(CatalogSelectionDeck);
+export default CatalogSelectionDeck;

--- a/src/components/courseCard/CourseCard.jsx
+++ b/src/components/courseCard/CourseCard.jsx
@@ -1,17 +1,15 @@
 /* eslint-disable camelcase */
 // variables taken from algolia not in camelcase
-import React from 'react';
 import PropTypes from 'prop-types';
 
 import { Badge, Card } from '@openedx/paragon';
-import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
+import { useIntl } from '@edx/frontend-platform/i18n';
 import messages from './CourseCard.messages';
 import defaultCardHeader from '../../static/default-card-header-light.png';
 import { formatPrice } from '../../utils/common';
 
-const CourseCard = ({
-  intl, onClick, original,
-}) => {
+const CourseCard = ({ onClick, original }) => {
+  const intl = useIntl();
   const {
     title,
     card_image_url,
@@ -77,7 +75,6 @@ CourseCard.defaultProps = {
 };
 
 CourseCard.propTypes = {
-  intl: intlShape.isRequired,
   onClick: PropTypes.func,
   original: PropTypes.shape({
     title: PropTypes.string,
@@ -99,4 +96,4 @@ CourseCard.propTypes = {
   }).isRequired,
 };
 
-export default injectIntl(CourseCard);
+export default CourseCard;

--- a/src/components/hero/Hero.jsx
+++ b/src/components/hero/Hero.jsx
@@ -1,9 +1,8 @@
-import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
+import { useIntl } from '@edx/frontend-platform/i18n';
 import {
   Container, Image, useMediaQuery, breakpoints,
 } from '@openedx/paragon';
 import PropTypes from 'prop-types';
-import React from 'react';
 import LargeHeroImageHiRes from '../../assets/hero-image-144px-hi-res.png';
 import SmallHeroImageHiRes from '../../assets/hero-image-hi-res.png';
 import LargeHeroImageLoRes from '../../assets/hero-image-large-lo-res.png';
@@ -65,7 +64,8 @@ Tablet.propTypes = {
   }).isRequired,
 };
 
-const Hero = ({ intl, text, highlight }) => {
+const Hero = ({ text, highlight }) => {
+  const intl = useIntl();
   const alt = intl.formatMessage(messages['hero.image.alt']);
 
   return (
@@ -92,9 +92,8 @@ Hero.defaultProps = {
 };
 
 Hero.propTypes = {
-  intl: intlShape.isRequired,
   text: PropTypes.string.isRequired,
   highlight: PropTypes.string,
 };
 
-export default injectIntl(Hero);
+export default Hero;

--- a/src/components/programCard/ProgramCard.jsx
+++ b/src/components/programCard/ProgramCard.jsx
@@ -1,18 +1,18 @@
 /* eslint-disable camelcase */
 // variables taken from algolia not in camelcase
-import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
 import { Badge, Icon, Card } from '@openedx/paragon';
 import { Program } from '@openedx/paragon/icons';
 
-import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
+import { useIntl } from '@edx/frontend-platform/i18n';
 import defaultCardHeader from '@edx/brand/paragon/images/card-imagecap-fallback.png';
 import messages from './ProgramCard.messages';
 import { getCourses } from '../../utils/common';
 
-const ProgramCard = ({ intl, onClick, original }) => {
+const ProgramCard = ({ onClick, original }) => {
+  const intl = useIntl();
   const {
     title,
     card_image_url,
@@ -86,7 +86,6 @@ ProgramCard.defaultProps = {
 };
 
 ProgramCard.propTypes = {
-  intl: intlShape.isRequired,
   onClick: PropTypes.func,
   original: PropTypes.shape({
     title: PropTypes.string,
@@ -103,4 +102,4 @@ ProgramCard.propTypes = {
   }).isRequired,
 };
 
-export default injectIntl(ProgramCard);
+export default ProgramCard;


### PR DESCRIPTION
### Description
As part of the project for improvements as follow up of react-unit-test-utils, we are going to replace all usages of the deprecated `injectIntl` HOC with the `useIntl()` hook from @edx/frontend-platform/i18n. It is a very straight-forward change, in order to accomplish this we did the following changes:

- In components we have to remove the old `injectIntl`, remove intl as a prop and use the hook instead.
- In tests we need to stop using `injectIntl` and just use the desired component wrapped in a `IntlProvider` (from @edx/frontend-platform/i18n).

Files to refactor:
- src/components/catalogSearchResults/CatalogSearchResults.jsx
- src/components/catalogSelectionDeck/CatalogSelectionDeck.jsx
- src/components/courseCard/CourseCard.jsx
- src/components/hero/Hero.jsx
- src/components/programCard/ProgramCard.jsx

#### Support Information
Closes #494 
Closes #496 