### PR TITLE
chore: Add CODEOWNERS for Enterprise/B2B squads

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Grant all Enterprise/B2B squads merge permission to entire repo.
+* @edx/enterprise-titans @edx/enterprise-markhors @edx/enterprise-sunrise @edx/enterprise-lakshy


### PR DESCRIPTION
gsre-3457

Add CODEOWNERS for Enterprise/B2B squads 
